### PR TITLE
fix(#982): bump prod log level to info

### DIFF
--- a/api/helpers/log-response.js
+++ b/api/helpers/log-response.js
@@ -1,5 +1,5 @@
 // Other http codes (like 200 or 204) are logged as "verbose" instead.
-const LOG_SEVERITY_INFO_FOR_CODES = [401, 403, 404, 409, 500];
+const LOG_SEVERITY_INFO_FOR_CODES = [401, 403, 404, 409];
 const LOG_SEVERITY_ERROR_FOR_CODES = [500];
 
 module.exports = {

--- a/config/log.js
+++ b/config/log.js
@@ -23,6 +23,6 @@ module.exports.log = {
    *                                                                          *
    ************************************************************************** */
 
-  level: process.env.NODE_ENV === 'production' ? 'error' : 'info',
+  level: 'info',
   noShip: true, // don't display "fancy" Sails ship when starting the app
 };


### PR DESCRIPTION
Fix #982

Always log at "info" level, even in production.