### PR TITLE
feat(search): properly handle deleted entrance

### DIFF
--- a/api/controllers/v1/entrance/find.js
+++ b/api/controllers/v1/entrance/find.js
@@ -25,7 +25,6 @@ module.exports = async (req, res) => {
     const params = { searchedItem: `Entrance of id ${req.params.id}` };
 
     if (!entrance) return res.notFound(`${params.searchedItem} not found`);
-
     if (entrance.isDeleted) {
       return ControllerService.treatAndConvert(
         req,
@@ -36,19 +35,16 @@ module.exports = async (req, res) => {
         toDeletedEntrance
       );
     }
-
     if (entrance.cave) {
       [entrance.cave.massifs, entrance.cave.entrances] = await Promise.all([
         CaveService.getMassifs(entrance.cave.id),
         TEntrance.find().where({ cave: entrance.cave.id }),
       ]);
-
       await Promise.all([
         NameService.setNames(entrance.cave.massifs, 'massif'),
         NameService.setNames([entrance.cave], 'cave'),
       ]);
     }
-
     [
       entrance.descriptions,
       entrance.locations,
@@ -64,7 +60,6 @@ module.exports = async (req, res) => {
       CommentService.getEntranceComments(entrance.id),
       ...entrance.documents.map((d) => DocumentService.getDocument(d.id)),
     ]);
-
     entrance.stats = CommentService.getStatsFromComments(entrance.comments);
 
     return ControllerService.treatAndConvert(

--- a/api/controllers/v1/massif/find.js
+++ b/api/controllers/v1/massif/find.js
@@ -3,7 +3,10 @@ const ErrorService = require('../../../services/ErrorService');
 const MassifService = require('../../../services/MassifService');
 const NameService = require('../../../services/NameService');
 const DescriptionService = require('../../../services/DescriptionService');
-const { toMassif } = require('../../../services/mapping/converters');
+const {
+  toMassif,
+  toDeletedMassif,
+} = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -15,10 +18,17 @@ module.exports = async (req, res) => {
       .populate('documents');
     const params = {};
     params.searchedItem = `Massif of id ${req.params.id}`;
-    if (!massif) {
-      return res.notFound(`${params.searchedItem} not found`);
+    if (!massif) return res.notFound(`${params.searchedItem} not found`);
+    if (massif.isDeleted) {
+      return ControllerService.treatAndConvert(
+        req,
+        null,
+        massif,
+        params,
+        res,
+        toDeletedMassif
+      );
     }
-
     // Populate entrances
     massif.entrances = await MassifService.getEntrances(massif.id);
     await NameService.setNames(massif.entrances, 'entrance');

--- a/api/controllers/v1/organization/find.js
+++ b/api/controllers/v1/organization/find.js
@@ -1,23 +1,35 @@
 const ControllerService = require('../../../services/ControllerService');
 const ErrorService = require('../../../services/ErrorService');
 const GrottoService = require('../../../services/GrottoService');
-const { toOrganization } = require('../../../services/mapping/converters');
+const {
+  toOrganization,
+  toDeletedOrganization,
+} = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
     const organization = await TGrotto.findOne(req.params.id)
+      .populate('author')
+      .populate('reviewer')
       .populate('names')
       .populate('cavers')
       .populate('documents')
       .populate('exploredCaves')
       .populate('partnerCaves');
-    if (!organization) {
-      return res.notFound({
-        message: `Organization of id ${req.params.id} not found.`,
-      });
-    }
     const params = {};
     params.searchedItem = `Organization of id ${req.params.id}`;
+    if (!organization) return res.notFound(`${params.searchedItem} not found`);
+    if (organization.isDeleted) {
+      return ControllerService.treatAndConvert(
+        req,
+        null,
+        organization,
+        params,
+        res,
+        toDeletedOrganization
+      );
+    }
+
     await GrottoService.populateOrganization(organization);
     return ControllerService.treatAndConvert(
       req,

--- a/api/models/TDocument.js
+++ b/api/models/TDocument.js
@@ -118,6 +118,12 @@ module.exports = {
       defaultsTo: false,
     },
 
+    redirectTo: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'redirect_to',
+    },
+
     entrance: {
       columnName: 'id_entrance',
       model: 'TEntrance',

--- a/api/models/TGrotto.js
+++ b/api/models/TGrotto.js
@@ -148,6 +148,12 @@ module.exports = {
       defaultsTo: false,
     },
 
+    redirectTo: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'redirect_to',
+    },
+
     country: {
       columnName: 'id_country',
       model: 'TCountry',

--- a/api/models/TMassif.js
+++ b/api/models/TMassif.js
@@ -42,6 +42,19 @@ module.exports = {
       columnName: 'date_reviewed',
     },
 
+    isDeleted: {
+      type: 'boolean',
+      allowNull: false,
+      columnName: 'is_deleted',
+      defaultsTo: false,
+    },
+
+    redirectTo: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'redirect_to',
+    },
+
     documents: {
       collection: 'TDocument',
       via: 'massif',

--- a/api/services/ElasticsearchService.js
+++ b/api/services/ElasticsearchService.js
@@ -47,12 +47,12 @@ const self = (module.exports = {
    * (document-collections and document-issues are excluded by default)
    * Params should contain an attribute 'query': others params are facultative.
    * @param {*} params  list of params of the request including :
-   *    @param {string}         query keyword(s) to use for the search
-   *    @param {integer}        from (optional, default = 0) number of first results to skip
-   *    @param {integer}        size (optional, default = 10) number of first results to return
-   *    @param {string}         resourceType (optional) resource type to search on.
+   *     {string}         query keyword(s) to use for the search
+   *     {integer}        from (optional, default = 0) number of first results to skip
+   *     {integer}        size (optional, default = 10) number of first results to return
+   *     {string}         resourceType (optional) resource type to search on.
    *            Must be one of INDEX_NAMES
-   *    @param {Array(string)}  resourceTypes (optional) resource types to search on.
+   *     {Array(string)}  resourceTypes (optional) resource types to search on.
    *            Must be an array containing some of the INDEX_NAMES
    */
   searchQuery: (params) =>
@@ -79,48 +79,56 @@ const self = (module.exports = {
             from: params.from ? params.from : 0,
             size: params.size ? params.size : 10,
             query: {
-              query_string: {
-                query: `*${self.sanitizeQuery(
-                  params.query
-                )}* + ${self.sanitizeQuery(params.query)}~${FUZZINESS}`,
-                fields: [
-                  // General useful fields
-                  'city^2',
-                  'country',
-                  'county',
-                  'description^0.5',
-                  'descriptions^0.5',
-                  'id',
-                  'name^5',
-                  'names^1.5',
-                  'region',
+              bool: {
+                must: {
+                  query_string: {
+                    query: `*${self.sanitizeQuery(
+                      params.query
+                    )}* + ${self.sanitizeQuery(params.query)}~${FUZZINESS}`,
+                    fields: [
+                      // General useful fields
+                      'city^2',
+                      'country',
+                      'county',
+                      'description^0.5',
+                      'descriptions^0.5',
+                      'id',
+                      'name^5',
+                      'names^1.5',
+                      'region',
 
-                  // ==== Entrances
-                  'bibliography^0.5',
-                  'caves',
-                  'location^0.5',
-                  'riggings',
+                      // ==== Entrances
+                      'bibliography^0.5',
+                      'caves',
+                      'location^0.5',
+                      'riggings',
 
-                  // ==== Grottos
-                  'custom_message',
+                      // ==== Grottos
+                      'custom_message',
 
-                  // ==== Massifs
+                      // ==== Massifs
 
-                  // ==== Document
-                  'authors',
-                  'identifier^1.5',
-                  'ref_bbs',
-                  'subjects',
-                  'title^2.7',
+                      // ==== Document
+                      'authors',
+                      'identifier^1.5',
+                      'ref_bbs',
+                      'subjects',
+                      'title^2.7',
 
-                  // ==== Cavers
-                  'mail^5',
-                  'nickname^3',
-                  'surname^4',
+                      // ==== Cavers
+                      'nickname^3',
+                      'surname^4',
 
-                  // ==== Languages
-                  'ref_name',
-                ],
+                      // ==== Languages
+                      'ref_name',
+                    ],
+                  },
+                },
+                filter: {
+                  term: {
+                    deleted: false,
+                  },
+                },
               },
             },
             highlight: {
@@ -239,7 +247,13 @@ const self = (module.exports = {
         index: `${params.resourceType}-index`,
         body: {
           query: {
-            bool: {},
+            bool: {
+              filter: {
+                term: {
+                  deleted: false,
+                },
+              },
+            },
           },
           highlight: {
             number_of_fragments: 3,

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -42,6 +42,18 @@ const c = {
     massifs: toList('massifs', source, c.toSimpleMassif),
   }),
 
+  toDeletedCave: (source) => ({
+    id: source.id,
+    '@id': String(source.id),
+    isDeleted: source.isDeleted,
+    redirectTo: source.redirectTo,
+    author: convertIfObject(source.author, c.toSimpleCaver),
+    reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+    dateInscription: source.dateInscription,
+    dateReviewed: source.dateReviewed,
+    name: getMainName(source),
+  }),
+
   toSimpleCave: (source) => ({
     id: source.id,
     name: getMainName(source),
@@ -213,6 +225,7 @@ const c = {
     // point: source.point,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+    isDeleted: source.isDeleted,
   }),
 
   toDescription: (source) => ({
@@ -259,6 +272,7 @@ const c = {
     result.refBbs = source.ref_bbs ? source.ref_bbs : source.refBbs;
     result.title = source.title;
     result.validationComment = source.validationComment;
+    result.isDeleted = source.isDeleted;
 
     // Convert objects
     const {
@@ -342,7 +356,9 @@ const c = {
     }
 
     // Convert collections
-    result.authors = toList('authors', source, toCaver);
+    result.authors = toList('authors', source, toCaver, {
+      filterDeleted: false,
+    });
     result.children = toList('children', source, toDocument);
     result.files = toList('files', source, toFile);
     const formattedDescriptions = toList(
@@ -390,6 +406,17 @@ const c = {
     return result;
   },
 
+  toDeletedDocument: (source) => ({
+    id: source.id,
+    '@id': String(source.id),
+    isDeleted: source.isDeleted,
+    redirectTo: source.redirectTo,
+    dateInscription: source.dateInscription,
+    dateReviewed: source.dateReviewed,
+    author: convertIfObject(source.author, c.toSimpleCaver),
+    reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
   toDocumentDuplicate: (source) => {
     const result = {
       ...DocumentDuplicateModel,
@@ -420,7 +447,6 @@ const c = {
     const result = {
       ...EntranceModel,
     };
-
     result['@id'] = String(source.id);
     result.id = source.id;
     result.isDeleted = source.isDeleted;
@@ -447,7 +473,6 @@ const c = {
     result.region = source.region;
     result.stats = source.stats;
     result.timeInfo = source.timeInfo; // Only used in random entrance
-
     // Convert objects
     if (source['cave name']) {
       // Elasticsearch
@@ -467,7 +492,6 @@ const c = {
     result.massifs = toList('massifs', source.cave ?? {}, c.toSimpleMassif);
     result.author = convertIfObject(source.author, c.toSimpleCaver);
     result.reviewer = convertIfObject(source.reviewer, c.toSimpleCaver);
-
     // Convert collections
     result.names = toList('names', source, c.toName);
     result.descriptions = toList('descriptions', source, c.toSimpleDescription);
@@ -476,7 +500,6 @@ const c = {
     result.histories = toList('histories', source, c.toSimpleHistory);
     result.locations = toList('locations', source, c.toSimpleLocation);
     result.riggings = toList('riggings', source, c.toSimpleRigging);
-
     // Massif from Elasticsearch
     if (source['massif name']) {
       result.massifs = {
@@ -486,26 +509,22 @@ const c = {
     return result;
   },
 
-  toDeletedEntrance: (source) => {
-    const result = {
-      ...EntranceModel,
-    };
-    result['@id'] = String(source.id);
-    result.id = source.id;
-    result.isDeleted = source.isDeleted;
-    result.isSensitive = source.isSensitive;
-    result.redirectTo = source.redirectTo;
-    result.dateInscription = source.dateInscription;
-    result.dateReviewed = source.dateReviewed;
-    result.country = source.country;
-    result.county = source.county;
-    result.city = source.city;
-    result.region = source.region;
-    result.name = getMainName(source);
-    result.author = convertIfObject(source.author, c.toSimpleCaver);
-    result.reviewer = convertIfObject(source.reviewer, c.toSimpleCaver);
-    return result;
-  },
+  toDeletedEntrance: (source) => ({
+    id: source.id,
+    '@id': String(source.id),
+    isDeleted: source.isDeleted,
+    isSensitive: source.isSensitive,
+    redirectTo: source.redirectTo,
+    author: convertIfObject(source.author, c.toSimpleCaver),
+    reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+    dateInscription: source.dateInscription,
+    dateReviewed: source.dateReviewed,
+    name: getMainName(source),
+    country: source.country,
+    county: source.county,
+    city: source.city,
+    region: source.region,
+  }),
 
   toSimpleEntrance: (source) => ({
     id: source.id,
@@ -515,6 +534,7 @@ const c = {
     country: source.country,
     latitude: parseFloat(source.latitude),
     longitude: parseFloat(source.longitude),
+    isDeleted: source.isDeleted,
   }),
 
   toEntranceDuplicate: (source) => {
@@ -620,6 +640,7 @@ const c = {
     result.names = source.names;
     result.nbCaves = source['nb caves']; // from Elasticsearch
     result.nbEntrances = source['nb entrances']; // from Elasticsearch
+    result.isDeleted = source.isDeleted;
 
     // Convert objects
     const { toCave, toCaver, toSimpleDescription, toDocument, toEntrance } =
@@ -640,9 +661,22 @@ const c = {
     return result;
   },
 
+  toDeletedMassif: (source) => ({
+    id: source.id,
+    '@id': String(source.id),
+    isDeleted: source.isDeleted,
+    redirectTo: source.redirectTo,
+    author: convertIfObject(source.author, c.toSimpleCaver),
+    reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+    dateInscription: source.dateInscription,
+    dateReviewed: source.dateReviewed,
+    name: getMainName(source),
+  }),
+
   toSimpleMassif: (source) => ({
     id: source.id,
     name: getMainName(source),
+    isDeleted: source.isDeleted,
   }),
 
   toName: (source) => ({
@@ -757,6 +791,7 @@ const c = {
     result.url = source.url;
     result.village = source.village;
     result.yearBirth = source.yearBirth;
+    result.isDeleted = source.isDeleted;
 
     // Convert collections
     const { toCave, toCaver, toDocument, toEntrance } = module.exports;
@@ -769,6 +804,22 @@ const c = {
 
     return result;
   },
+
+  toDeletedOrganization: (source) => ({
+    id: source.id,
+    '@id': String(source.id),
+    isDeleted: source.isDeleted,
+    redirectTo: source.redirectTo,
+    author: convertIfObject(source.author, c.toSimpleCaver),
+    reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+    dateInscription: source.dateInscription,
+    dateReviewed: source.dateReviewed,
+    name: getMainName(source),
+    country: source.country,
+    county: source.county,
+    city: source.city,
+    region: source.region,
+  }),
 
   toSimpleRigging: (source) => ({
     id: source.id,

--- a/api/services/mapping/utils.js
+++ b/api/services/mapping/utils.js
@@ -4,34 +4,38 @@ module.exports = {
   /**
    * Apply a function to each item of an array of data. If data[key] is not an Array, return it as is.
    * @param {string} key
-   * @param {Array} data array of data to be converted
-   * @param {(item) => Array} fn function to apply to each data item
-   * @returns {Array | Object}
+   * @param {Object} data Object containing the `key` to convert
+   * @param {(Object) => Object} fn function to apply to each data item
+   * @param {Boolean} filterDeleted If true then all items with the isDeleted property set
+   *                      to true will be filtered from the array before applying
+   *                      the given function to apply.
+   * @returns Array
    */
-  toList: (key, data, fn) => {
-    // Check arguments
+  toList: (key, data, fn, { filterDeleted = true } = {}) => {
     if (!data[key]) {
       return [];
     }
     if (!(data[key] instanceof Array)) {
+      if (filterDeleted && data[key].isDeleted) return null;
       return data[key];
     }
-
-    // Compute
-    const results = [];
-    data[key].forEach((item) => results.push(fn(item)));
-    return results;
+    return data[key]
+      .filter((obj) => !filterDeleted || !obj.isDeleted)
+      .map((item) => fn(item));
   },
 
   /**
    * Controllers expect the results to be returned in an object {key: results}
    * @param {string} key
    * @param {Array} data
-   * @param {*} fn
+   * @param {(Object) => Object} fn @see toList
+   * @param {Boolean} filterDeleted @see toList
    * @returns {Object}
    */
-  toListFromController: (key, data, fn) => ({
-    [key]: module.exports.toList(key, { [key]: data }, fn),
+  toListFromController: (key, data, fn, { filterDeleted = true } = {}) => ({
+    [key]: module.exports.toList(key, { [key]: data }, fn, {
+      filterDeleted,
+    }),
   }),
 
   convertIfObject: (data, fn) => (data instanceof Object ? fn(data) : data),

--- a/logstash.conf
+++ b/logstash.conf
@@ -4,7 +4,7 @@
 #################################################
 
 input {
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -14,8 +14,8 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT  
-        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue, 
+      SELECT
+        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue,
         doc.id_identifier_type, doc.ref_bbs, doc.publication_other_bbs_old,
         doc.publication_fascicule_bbs_old,
         t_description.title as title,
@@ -30,7 +30,8 @@ input {
         ty.id as \"type id\",
         ty.name as \"type name\",
         contributor.id as \"contributor id\",
-        contributor.nickname as \"contributor nickname\"
+        contributor.nickname as \"contributor nickname\",
+        doc.is_deleted as deleted
       FROM t_document as doc
       LEFT JOIN j_document_subject jds ON jds.id_document = doc.id
       LEFT JOIN (
@@ -38,17 +39,19 @@ input {
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) lib ON lib.id = doc.id_library
       LEFT JOIN (
         SELECT g.id, n.name as name
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) editor ON editor.id = doc.id_editor
       LEFT JOIN j_document_caver_author jdca ON jdca.id_document = doc.id
 	    LEFT JOIN t_caver contributor ON contributor.id = doc.id_author
       LEFT JOIN t_caver caver ON caver.id = jdca.id_caver
-      LEFT JOIN t_description ON t_description.id_document = doc.id
+      LEFT JOIN t_description ON t_description.id_document = doc.id AND t_description.is_deleted = false
       LEFT JOIN j_document_region jdcr ON jdcr.id_document = doc.id
       LEFT JOIN t_region r ON r.id = jdcr.id_region
       LEFT JOIN t_type ty ON ty.id = doc.id_type
@@ -58,7 +61,7 @@ input {
     "
     tags => ["document"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -68,8 +71,8 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT  
-        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue, 
+      SELECT
+        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue,
         doc.id_identifier_type, doc.ref_bbs, doc.publication_other_bbs_old,
         doc.publication_fascicule_bbs_old,
         t_description.title as title,
@@ -84,7 +87,8 @@ input {
         ty.id as \"type id\",
         ty.name as \"type name\",
         contributor.id as \"contributor id\",
-        contributor.nickname as \"contributor nickname\"
+        contributor.nickname as \"contributor nickname\",
+        doc.is_deleted as deleted
       FROM t_document as doc
       LEFT JOIN j_document_subject jds ON jds.id_document = doc.id
       LEFT JOIN (
@@ -92,28 +96,29 @@ input {
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) lib ON lib.id = doc.id_library
       LEFT JOIN (
         SELECT g.id, n.name as name
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) editor ON editor.id = doc.id_editor
       LEFT JOIN j_document_caver_author jdca ON jdca.id_document = doc.id
       LEFT JOIN t_caver contributor ON contributor.id = doc.id_author
       LEFT JOIN t_caver caver ON caver.id = jdca.id_caver
-      LEFT JOIN t_description ON t_description.id_document = doc.id
+      LEFT JOIN t_description ON t_description.id_document = doc.id AND t_description.is_deleted = false
       LEFT JOIN j_document_region jdcr ON jdcr.id_document = doc.id
       LEFT JOIN t_region r ON r.id = jdcr.id_region
       LEFT JOIN t_type ty ON ty.id = doc.id_type
       WHERE is_validated = true
-      AND doc.is_deleted = false
       AND ty.name = 'Collection'
       GROUP BY doc.id, t_description.id, lib.id, lib.name, editor.id, editor.name, ty.id, ty.name, contributor.id, contributor.nickname
     "
     tags => ["document-collection"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -123,8 +128,8 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT  
-        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue, 
+      SELECT
+        doc.id::varchar, doc.date_publication, doc.identifier, doc.issue,
         doc.id_identifier_type, doc.ref_bbs, doc.publication_other_bbs_old,
         doc.publication_fascicule_bbs_old,
         t_description.title as title,
@@ -139,7 +144,8 @@ input {
         ty.id as \"type id\",
         ty.name as \"type name\",
         contributor.id as \"contributor id\",
-        contributor.nickname as \"contributor nickname\"
+        contributor.nickname as \"contributor nickname\",
+        doc.is_deleted as deleted
       FROM t_document as doc
       LEFT JOIN j_document_subject jds ON jds.id_document = doc.id
       LEFT JOIN (
@@ -147,28 +153,29 @@ input {
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) lib ON lib.id = doc.id_library
       LEFT JOIN (
         SELECT g.id, n.name as name
         FROM t_grotto g
         LEFT JOIN t_name n ON g.id = n.id_grotto
         WHERE n.is_main = true
+        AND g.is_deleted = false
       ) editor ON editor.id = doc.id_editor
       LEFT JOIN j_document_caver_author jdca ON jdca.id_document = doc.id
       LEFT JOIN t_caver contributor ON contributor.id = doc.id_author
       LEFT JOIN t_caver caver ON caver.id = jdca.id_caver
-      LEFT JOIN t_description ON t_description.id_document = doc.id
+      LEFT JOIN t_description ON t_description.id_document = doc.id AND t_description.is_deleted = false
       LEFT JOIN j_document_region jdcr ON jdcr.id_document = doc.id
       LEFT JOIN t_region r ON r.id = jdcr.id_region
       LEFT JOIN t_type ty ON ty.id = doc.id_type
       WHERE is_validated = true
-      AND doc.is_deleted = false
       AND ty.name = 'Issue'
       GROUP BY doc.id, t_description.id, lib.id, lib.name, editor.id, editor.name, ty.id, ty.name, contributor.id, contributor.nickname
     "
     tags => ["document-issue"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -178,55 +185,76 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT 
-        e.id::varchar,
-        e.city, 
-        e.county, 
-        e.region,
-       	e.year_discovery,
-       	e.latitude,
-       	e.longitude,
-        string_agg(DISTINCT n.name, ', ') AS names,
-        string_agg(d.title || ' ' || d.body, ', ') AS descriptions,
-        AVG(c.approach) AS approach,
-        AVG(c.aestheticism) AS aestheticism,
-        AVG(c.caving) AS caving,
-        main_n.main_name AS name,
-        cave_and_massif.name_cave AS \"cave name\",
-        cave_and_massif.length_cave AS \"cave length\",
-        cave_and_massif.depth_cave AS \"cave depth\",
-        cave_and_massif.is_diving_cave AS \"cave is diving\",
-        cave_and_massif.name_massif AS \"massif name\",
-        country.native_name AS country,
-        country.iso3 AS \"country code\"
-      FROM t_entrance AS e
-      LEFT JOIN t_name n ON n.id_entrance = e.id
-      LEFT JOIN t_description d on d.id_entrance = e.id
-      LEFT JOIN t_comment c on c.id_entrance = e.id
-      LEFT JOIN (
-        SELECT t_name.id_entrance AS id, t_name.name AS main_name
-        FROM t_name
-        WHERE t_name.is_main = true
-      ) main_n ON main_n.id = e.id
-      LEFT JOIN (
-        SELECT 
-          c.id AS id_cave, c.depth AS depth_cave, c.length AS length_cave, c.is_diving AS is_diving_cave,
-          n1.name AS name_cave, n2.name AS name_massif
-        FROM t_cave c
-        LEFT JOIN t_name n1 ON n1.id_cave = c.id
-        LEFT JOIN t_massif m ON ST_Contains(ST_SetSRID(m.geog_polygon::geometry, 4326), ST_SetSRID(ST_MakePoint(c.longitude, c.latitude), 4326))
-        LEFT JOIN t_name n2 ON n2.id_massif = m.id
-        WHERE n1.is_main = true
-        AND n2.is_main = true
-      ) cave_and_massif ON cave_and_massif.id_cave = e.id_cave
-      LEFT JOIN t_country country ON country.iso = e.id_country 
-      WHERE e.is_deleted = false
-      GROUP BY e.id, main_n.main_name, cave_and_massif.name_cave, cave_and_massif.depth_cave, 
-	  	  cave_and_massif.length_cave, cave_and_massif.is_diving_cave, cave_and_massif.name_massif, country.iso3, country.native_name
+    SELECT e.id::varchar,
+           e.city,
+           e.county,
+           e.region,
+           e.year_discovery,
+           e.latitude,
+           e.longitude,
+           string_agg(DISTINCT n.name, ', ') AS names,
+           string_agg(d.title || ' ' || d.body, ', ') AS descriptions,
+           AVG(c.approach) AS approach,
+           AVG(c.aestheticism) AS aestheticism,
+           AVG(c.caving) AS caving,
+           main_n.main_name AS name,
+           cave.name_cave AS \"cave name\",
+           cave.length_cave AS \"cave length\",
+           cave.depth_cave AS \"cave depth\",
+           cave.is_diving_cave AS \"cave is diving\",
+           massif.name_massif AS \"massif name\",
+           CONCAT_WS(', ', country.native_name, country.en_name, country.es_name, country.fr_name, country.de_name, country.bg_name, country.it_name, country.ca_name, country.nl_name, country.rs_name) AS country,
+           country.iso3 AS \"country code\",
+           e.is_deleted AS deleted
+    FROM t_entrance AS e
+    LEFT JOIN t_name n ON n.id_entrance = e.id
+    LEFT JOIN t_description d ON d.id_entrance = e.id AND d.is_deleted = false
+    LEFT JOIN t_comment c ON c.id_entrance = e.id AND c.is_deleted = false
+    LEFT JOIN
+      (SELECT t_name.id_entrance AS id,
+              t_name.name AS main_name
+       FROM t_name
+       WHERE t_name.is_main = TRUE ) main_n ON main_n.id = e.id
+    LEFT JOIN
+      (SELECT c.id AS id_cave,
+              c.depth AS depth_cave,
+              c.length AS length_cave,
+              c.is_diving AS is_diving_cave,
+              n1.name AS name_cave
+       FROM t_cave c
+       LEFT JOIN t_name n1 ON n1.id_cave = c.id
+       WHERE n1.is_main = TRUE
+        AND c.is_deleted = FALSE) cave ON cave.id_cave = e.id_cave
+    LEFT JOIN
+      (SELECT n2.name AS name_massif,
+              massif.geog_polygon AS geog_polygon
+       FROM t_massif massif
+       LEFT JOIN t_name n2 ON n2.id_massif = massif.id
+       WHERE n2.is_main = TRUE
+         AND massif.is_deleted = FALSE ) massif ON ST_Contains(ST_SetSRID(geog_polygon::geometry, 4326), ST_SetSRID(ST_MakePoint(e.longitude, e.latitude), 4326))
+    LEFT JOIN t_country country ON country.iso = e.id_country
+    GROUP BY e.id,
+             main_n.main_name,
+             cave.name_cave,
+             cave.depth_cave,
+             cave.length_cave,
+             cave.is_diving_cave,
+             massif.name_massif,
+             country.iso3,
+             country.native_name,
+             country.en_name,
+             country.es_name,
+             country.fr_name,
+             country.de_name,
+             country.bg_name,
+             country.it_name,
+             country.ca_name,
+             country.nl_name,
+             country.rs_name;
     "
     tags => ["entrance"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -242,10 +270,11 @@ input {
         string_agg(d.title || ' ' || d.body, '## ') AS descriptions,
         COUNT(caves) AS \"nb caves\",
         SUM(caves.nb_entrances) AS \"nb entrances\",
-        main_n.main_name AS name
+        main_n.main_name AS name,
+        m.is_deleted as deleted
       FROM t_massif AS m
       LEFT JOIN t_name n ON n.id_massif = m.id
-      LEFT JOIN t_description d ON d.id_massif = m.id
+      LEFT JOIN t_description d ON d.id_massif = m.id AND d.is_deleted = false
       LEFT JOIN (
         SELECT t_name.id_massif AS id, t_name.name AS main_name
         FROM t_name
@@ -255,14 +284,14 @@ input {
         SELECT c.id AS id, c.latitude, c.longitude, COUNT(e) AS nb_entrances
         FROM t_cave c
         LEFT JOIN t_entrance e ON e.id_cave = c.id
+        WHERE c.is_deleted = FALSE
         GROUP BY c.id
       ) caves ON ST_Contains(ST_SetSRID(m.geog_polygon::geometry, 4326), ST_SetSRID(ST_MakePoint(caves.longitude, caves.latitude), 4326))
-      WHERE m.is_deleted = false
       GROUP BY m.id, main_n.main_name
     "
     tags => ["massif"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -282,7 +311,8 @@ input {
         COUNT(jgc.id_caver) AS \"nb cavers\",
         main_n.main_name AS name,
         c.iso3 AS \"country code\",
-        c.native_name AS country
+        CONCAT_WS(', ', c.native_name, c.en_name, c.es_name, c.fr_name, c.de_name, c.bg_name, c.it_name, c.ca_name, c.nl_name, c.rs_name) AS country,
+        g.is_deleted as deleted
       FROM t_grotto AS g
       LEFT JOIN t_name n ON n.id_grotto = g.id
       LEFT JOIN j_grotto_caver jgc ON jgc.id_grotto = g.id
@@ -292,12 +322,11 @@ input {
         WHERE t_name.is_main = true
       ) main_n ON main_n.id = g.id
       LEFT JOIN t_country c ON c.iso = g.id_country
-      WHERE g.is_deleted = false
-      GROUP BY g.id, main_n.main_name, c.iso3, c.native_name 
+      GROUP BY g.id, main_n.main_name, c.iso3, c.native_name, c.en_name, c.es_name, c.fr_name, c.de_name, c.bg_name, c.it_name, c.ca_name, c.nl_name, c.rs_name
     "
     tags => ["grotto"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -307,9 +336,9 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT 
+      SELECT
         c.id::varchar,
-        c.name, 
+        c.name,
         c.surname,
         c.nickname,
         c.mail,
@@ -321,7 +350,7 @@ input {
     "
     tags => ["caver"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -331,11 +360,12 @@ input {
     jdbc_driver_class => "org.postgresql.Driver"
     # our query
     statement => "
-      SELECT 
+      SELECT
         c.id::varchar, c.depth, c.length, c.is_diving, c.temperature, c.size_coef,
         string_agg(DISTINCT n.name, ', ') AS names,
         main_n.main_name AS name,
-        string_agg(d.title || ' ' || d.body, ', ') AS descriptions
+        string_agg(d.title || ' ' || d.body, ', ') AS descriptions,
+        c.is_deleted as deleted
       FROM t_cave AS c
       LEFT JOIN (
         SELECT t_name.id_cave AS id, t_name.name AS main_name
@@ -343,13 +373,13 @@ input {
         WHERE t_name.is_main = true
       ) main_n ON main_n.id = c.id
       LEFT JOIN t_name n ON n.id_cave = c.id
-      LEFT JOIN t_description d ON d.id_cave = c.id
-      WHERE name is not null AND c.is_deleted = FALSE
+      LEFT JOIN t_description d ON d.id_cave = c.id AND is_deleted = false
+      WHERE name is not null
       GROUP BY c.id, main_n.main_name
     "
     tags => ["cave"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"
@@ -373,7 +403,8 @@ input {
           string_agg(DISTINCT n.name, ', ') AS names,
           main_n.main_name AS name,
           string_agg(d.title || ' ' || d.body, ', ') AS descriptions,
-          count(e.id_cave) AS nb_entrances
+          count(e.id_cave) AS nb_entrances,
+          c.is_deleted as deleted
         FROM
           t_cave AS c
         LEFT JOIN (
@@ -389,12 +420,11 @@ input {
         LEFT JOIN t_name n ON
           n.id_cave = c.id
         LEFT JOIN t_description d ON
-          d.id_cave = c.id
+          d.id_cave = c.id AND d.is_deleted = false
         LEFT JOIN t_entrance e ON
-          e.id_cave = c.id
+          e.id_cave = c.id AND e.is_deleted = false
         WHERE
           NAME IS NOT NULL
-          AND c.is_deleted = FALSE
         GROUP BY
           c.id,
           main_n.main_name
@@ -404,7 +434,7 @@ input {
     "
     tags => ["network"]
   }
-  jdbc { 
+  jdbc {
     jdbc_connection_string => "${JDBC_POSTGRESQL}"
     # The user we wish to execute our statement as
     jdbc_user => "${JDBC_USER}"

--- a/test/integration/2_utils/toList.test.js
+++ b/test/integration/2_utils/toList.test.js
@@ -1,0 +1,81 @@
+const should = require('should');
+const { toList } = require('../../../api/services/mapping/utils');
+
+describe('toList utils', () => {
+  it('should apply a function to a list of object', async () => {
+    function toSimpleCave(source) {
+      return { id: source.id, name: source.name };
+    }
+
+    const testData = {
+      caves: [
+        {
+          id: 1,
+          name: 'test',
+          other: 'other',
+          isDeleted: true,
+        },
+        {
+          id: 2,
+          name: 'test2',
+          other: 'other2',
+          isDeleted: false,
+        },
+      ],
+      cave: {
+        id: 1,
+        name: 'test',
+        other: 'other',
+        isDeleted: true,
+      },
+      noDeleted: [
+        {
+          id: 1,
+          name: 'test',
+          other: 'other',
+        },
+        {
+          id: 2,
+          name: 'test2',
+          other: 'other2',
+        },
+      ],
+    };
+
+    const res = toList('caves', testData, toSimpleCave, {
+      filterDeleted: false,
+    });
+    should(res).deepEqual([
+      { id: 1, name: 'test' },
+      { id: 2, name: 'test2' },
+    ]);
+    const res2 = toList('caves', testData, toSimpleCave, {
+      filterDeleted: true,
+    });
+    should(res2).deepEqual([{ id: 2, name: 'test2' }]);
+
+    // If data[key] is not an Array, return it as is.
+    const res3 = toList('cave', testData, toSimpleCave, {
+      filterDeleted: false,
+    });
+    should(res3).deepEqual({
+      id: 1,
+      name: 'test',
+      other: 'other',
+      isDeleted: true,
+    });
+
+    const res4 = toList('cave', testData, toSimpleCave, {
+      filterDeleted: true,
+    });
+    should(res4).deepEqual(null);
+
+    const res5 = toList('noDeleted', testData, toSimpleCave, {
+      filterDeleted: true,
+    });
+    should(res5).deepEqual([
+      { id: 1, name: 'test' },
+      { id: 2, name: 'test2' },
+    ]);
+  });
+});


### PR DESCRIPTION
This PR fix and improve the deleted concept in the grottocenter API : 
- add missing `is_deleted` property on multiple models (and return it in API response)
- add missing `redirect_to` property on massif (and return it in API response)
- add a way to filter the `is_deleted` entities with the `toList` function of the utils.
- filter "deleted" entites returned by most routes (using the toList function above in the converters)
- improve the logstash file to save the "deleted" state of every items from ES (fix #1075)
- imporve the logstash file to store the country names in whole possible language  (fix #588)
- add a "toDeletedXXX" converter for all the main entities which can be marked as deleted (Cave, Massif, Document, ...)