### PR TITLE
fix(#1088): fix doc language edit when doc is validated

### DIFF
--- a/api/controllers/v1/document/update.js
+++ b/api/controllers/v1/document/update.js
@@ -1,19 +1,12 @@
-const ramda = require('ramda');
 const ControllerService = require('../../../services/ControllerService');
-const DescriptionService = require('../../../services/DescriptionService');
 const DocumentService = require('../../../services/DocumentService');
 const ErrorService = require('../../../services/ErrorService');
 const FileService = require('../../../services/FileService');
-const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const { toDocument } = require('../../../services/mapping/converters');
 
 const { INVALID_FORMAT, INVALID_NAME, ERROR_DURING_UPLOAD_TO_AZURE } =
   FileService;
-const {
-  NOTIFICATION_TYPES,
-  NOTIFICATION_ENTITIES,
-} = require('../../../services/NotificationService');
 
 module.exports = async (req, res) => {
   const docWithModif = await TDocument.findOne({
@@ -82,33 +75,18 @@ module.exports = async (req, res) => {
   // Update json data (upcoming modifications which need to be validated)
   const dataFromClient = await DocumentService.getConvertedDataFromClient(req);
   const descriptionData = await DocumentService.getLangDescDataFromClient(req);
-  const jsonData = {
-    ...dataFromClient,
-    ...descriptionData,
-    id: req.param('id'),
-    author: req.token.id,
-    newFiles: ramda.isEmpty(newFilesArray) ? undefined : newFilesArray,
-  };
+
   try {
-    const updatedDocument = await TDocument.updateOne(req.param('id')).set({
-      isValidated: false,
-      dateValidation: null,
-      dateReviewed: new Date(),
-      modifiedDocJson: jsonData,
-    });
+    const updatedDocument = await DocumentService.updateDocument(
+      req,
+      dataFromClient,
+      descriptionData,
+      newFilesArray
+    );
     if (!updatedDocument) {
       return res.notFound();
     }
 
-    await NotificationService.notifySubscribers(
-      req,
-      updatedDocument,
-      req.token.id,
-      NOTIFICATION_TYPES.UPDATE,
-      NOTIFICATION_ENTITIES.DOCUMENT
-    );
-
-    await DescriptionService.setDocumentDescriptions(updatedDocument, false);
     const params = {};
     params.controllerMethod = 'DocumentController.update';
     return ControllerService.treatAndConvert(

--- a/api/models/JDocumentLanguage.js
+++ b/api/models/JDocumentLanguage.js
@@ -22,7 +22,7 @@ module.exports = {
     isMain: {
       columnName: 'is_main',
       allowNull: false,
-      defaultsTo: false,
+      defaultsTo: true,
       type: 'boolean',
     },
   },


### PR DESCRIPTION
Fix #1088

## 🤔 What

Multiple doc validation was not handling the doc language correctly. 

## 🤷‍♂️ Why

`TDocument.updateOne()` doesn't handle collections (languages is a document collection).

## 🔍 How

`replaceCollection()` must be used for this case.

I also refactored the `updateDocument()` method, moving it from controller to service. 
Since only one language per document is used, I have set the `JDocumentLanguage.isMain` to true by default.