### PR TITLE
[NOTIFICATIONS] Fix related entity link

### DIFF
--- a/api/controllers/v1/comment/create.js
+++ b/api/controllers/v1/comment/create.js
@@ -8,7 +8,7 @@ const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const CommentService = require('../../../services/CommentService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
-const { toComment } = require('../../../services/mapping/converters');
+const { toSimpleComment } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -73,7 +73,7 @@ module.exports = async (req, res) => {
       populatedComment,
       { controllerMethod: 'CommentController.create' },
       res,
-      toComment
+      toSimpleComment
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/comment/update.js
+++ b/api/controllers/v1/comment/update.js
@@ -7,7 +7,7 @@ const {
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const CommentService = require('../../../services/CommentService');
-const { toComment } = require('../../../services/mapping/converters');
+const { toSimpleComment } = require('../../../services/mapping/converters');
 
 const { checkRight } = sails.helpers;
 
@@ -81,7 +81,7 @@ module.exports = async (req, res) => {
       populatedComment,
       { controllerMethod: 'CommentController.update' },
       res,
-      toComment
+      toSimpleComment
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/description/create.js
+++ b/api/controllers/v1/description/create.js
@@ -8,7 +8,7 @@ const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
 } = require('../../../services/NotificationService');
-const { toDescription } = require('../../../services/mapping/converters');
+const { toSimpleDescription } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -70,7 +70,7 @@ module.exports = async (req, res) => {
       populatedDescription,
       { controllerMethod: 'DescriptionController.create' },
       res,
-      toDescription
+      toSimpleDescription
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/description/update.js
+++ b/api/controllers/v1/description/update.js
@@ -7,7 +7,7 @@ const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
 } = require('../../../services/NotificationService');
-const { toDescription } = require('../../../services/mapping/converters');
+const { toSimpleDescription } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -68,7 +68,7 @@ module.exports = async (req, res) => {
       populatedDescription,
       { controllerMethod: 'DescriptionController.update' },
       res,
-      toDescription
+      toSimpleDescription
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/history/create.js
+++ b/api/controllers/v1/history/create.js
@@ -8,7 +8,7 @@ const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const HistoryService = require('../../../services/HistoryService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
-const { toHistory } = require('../../../services/mapping/converters');
+const { toSimpleHistory } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -67,7 +67,7 @@ module.exports = async (req, res) => {
       populatedHistory,
       { controllerMethod: 'HistoryController.create' },
       res,
-      toHistory
+      toSimpleHistory
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/history/update.js
+++ b/api/controllers/v1/history/update.js
@@ -7,7 +7,7 @@ const {
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const HistoryService = require('../../../services/HistoryService');
-const { toHistory } = require('../../../services/mapping/converters');
+const { toSimpleHistory } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -63,7 +63,7 @@ module.exports = async (req, res) => {
       populatedHistory,
       { controllerMethod: 'HistoryController.update' },
       res,
-      toHistory
+      toSimpleHistory
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/location/create.js
+++ b/api/controllers/v1/location/create.js
@@ -8,7 +8,7 @@ const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
 const LocationService = require('../../../services/LocationService');
-const { toLocation } = require('../../../services/mapping/converters');
+const { toSimpleLocation } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -68,7 +68,7 @@ module.exports = async (req, res) => {
       locationPopulated,
       { controllerMethod: 'LocationController.create' },
       res,
-      toLocation
+      toSimpleLocation
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/location/update.js
+++ b/api/controllers/v1/location/update.js
@@ -3,7 +3,7 @@ const ErrorService = require('../../../services/ErrorService');
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const LocationService = require('../../../services/LocationService');
-const { toLocation } = require('../../../services/mapping/converters');
+const { toSimpleLocation } = require('../../../services/mapping/converters');
 const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
@@ -66,7 +66,7 @@ module.exports = async (req, res) => {
       populatedLocation,
       { controllerMethod: 'LocationController.update' },
       res,
-      toLocation
+      toSimpleLocation
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/rigging/create.js
+++ b/api/controllers/v1/rigging/create.js
@@ -9,7 +9,7 @@ const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const RiggingService = require('../../../services/RiggingService');
 const ParametersValidatorService = require('../../../services/ParametersValidatorService');
-const { toRigging } = require('../../../services/mapping/converters');
+const { toSimpleRigging } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   try {
@@ -74,7 +74,7 @@ module.exports = async (req, res) => {
       populatedRigging,
       { controllerMethod: 'RiggingController.create' },
       res,
-      toRigging
+      toSimpleRigging
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/controllers/v1/rigging/update.js
+++ b/api/controllers/v1/rigging/update.js
@@ -3,7 +3,7 @@ const ErrorService = require('../../../services/ErrorService');
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
 const RiggingService = require('../../../services/RiggingService');
-const { toRigging } = require('../../../services/mapping/converters');
+const { toSimpleRigging } = require('../../../services/mapping/converters');
 const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
@@ -78,7 +78,7 @@ module.exports = async (req, res) => {
       populatedRigging,
       { controllerMethod: 'RiggingController.update' },
       res,
-      toRigging
+      toSimpleRigging
     );
   } catch (e) {
     return ErrorService.getDefaultErrorHandler(res)(e);

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -122,7 +122,7 @@ const c = {
     nickname: source.nickname,
   }),
 
-  toComment: (source) => ({
+  toSimpleComment: (source) => ({
     id: source.id,
     isDeleted: source.isDeleted,
     language: source.language,
@@ -139,6 +139,12 @@ const c = {
     // alert: source.alert; // TODO ?
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
+  toComment: (source) => ({
+    ...c.toSimpleComment(source),
+    entrance: convertIfObject(source.entrance, c.toSimpleEntrance),
+    cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
   toCompleteSearchResult: (source) => {
@@ -465,7 +471,7 @@ const c = {
     // Convert collections
     result.names = toList('names', source, c.toName);
     result.descriptions = toList('descriptions', source, c.toSimpleDescription);
-    result.comments = toList('comments', source, c.toComment);
+    result.comments = toList('comments', source, c.toSimpleComment);
     result.documents = toList('documents', source, c.toDocument);
     result.histories = toList('histories', source, c.toHistory);
     result.locations = toList('locations', source, c.toSimpleLocation);

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -473,7 +473,7 @@ const c = {
     result.descriptions = toList('descriptions', source, c.toSimpleDescription);
     result.comments = toList('comments', source, c.toSimpleComment);
     result.documents = toList('documents', source, c.toDocument);
-    result.histories = toList('histories', source, c.toHistory);
+    result.histories = toList('histories', source, c.toSimpleHistory);
     result.locations = toList('locations', source, c.toSimpleLocation);
     result.riggings = toList('riggings', source, c.toRigging);
 
@@ -546,7 +546,7 @@ const c = {
     };
   },
 
-  toHistory: (source) => ({
+  toSimpleHistory: (source) => ({
     id: source.id,
     body: source.body,
     dateInscription: source.dateInscription,
@@ -556,6 +556,12 @@ const c = {
     isDeleted: source.isDeleted,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
+  toHistory: (source) => ({
+    ...c.toSimpleHistory(source),
+    entrance: convertIfObject(source.entrance, c.toSimpleEntrance),
+    cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
   toLanguage: (source) => {

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -475,7 +475,7 @@ const c = {
     result.documents = toList('documents', source, c.toDocument);
     result.histories = toList('histories', source, c.toSimpleHistory);
     result.locations = toList('locations', source, c.toSimpleLocation);
-    result.riggings = toList('riggings', source, c.toRigging);
+    result.riggings = toList('riggings', source, c.toSimpleRigging);
 
     // Massif from Elasticsearch
     if (source['massif name']) {
@@ -770,7 +770,7 @@ const c = {
     return result;
   },
 
-  toRigging: (source) => ({
+  toSimpleRigging: (source) => ({
     id: source.id,
     isDeleted: source.isDeleted,
     title: source.title,
@@ -781,6 +781,12 @@ const c = {
     obstacles: RiggingService.deserializeForAPI(source),
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
+  toRigging: (source) => ({
+    ...c.toSimpleRigging(source),
+    entrance: convertIfObject(source.entrance, c.toSimpleEntrance),
+    cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
   toSearchResult: (source) => {

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -468,7 +468,7 @@ const c = {
     result.comments = toList('comments', source, c.toComment);
     result.documents = toList('documents', source, c.toDocument);
     result.histories = toList('histories', source, c.toHistory);
-    result.locations = toList('locations', source, c.toLocation);
+    result.locations = toList('locations', source, c.toSimpleLocation);
     result.riggings = toList('riggings', source, c.toRigging);
 
     // Massif from Elasticsearch
@@ -574,7 +574,7 @@ const c = {
     return result;
   },
 
-  toLocation: (source) => ({
+  toSimpleLocation: (source) => ({
     id: source.id,
     body: source.body,
     dateInscription: source.dateInscription,
@@ -585,6 +585,13 @@ const c = {
     isDeleted: source.isDeleted,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
+  toLocation: (source) => ({
+    ...c.toSimpleLocation(source),
+    entrance: convertIfObject(source.entrance, c.toSimpleEntrance),
+    massif: convertIfObject(source.massif, c.toSimpleMassif),
+    cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
   toMassif: (source) => {

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -36,7 +36,7 @@ const c = {
     longitude: parseFloat(source.longitude),
 
     names: toList('names', source, c.toName),
-    descriptions: toList('descriptions', source, c.toDescription),
+    descriptions: toList('descriptions', source, c.toSimpleDescription),
     entrances: toList('entrances', source, c.toSimpleEntrance),
     documents: toList('documents', source, c.toDocument),
     massifs: toList('massifs', source, c.toSimpleMassif),
@@ -196,7 +196,7 @@ const c = {
     return res;
   },
 
-  toDescription: (source) => ({
+  toSimpleDescription: (source) => ({
     id: source.id,
     language: source.language,
     title: source.title,
@@ -207,6 +207,13 @@ const c = {
     // point: source.point,
     author: convertIfObject(source.author, c.toSimpleCaver),
     reviewer: convertIfObject(source.reviewer, c.toSimpleCaver),
+  }),
+
+  toDescription: (source) => ({
+    ...c.toSimpleDescription(source),
+    entrance: convertIfObject(source.entrance, c.toSimpleEntrance),
+    massif: convertIfObject(source.massif, c.toSimpleMassif),
+    cave: convertIfObject(source.cave, c.toSimpleCave),
   }),
 
   toDocument: (source) => {
@@ -250,7 +257,7 @@ const c = {
     // Convert objects
     const {
       toCaver,
-      toDescription,
+      toSimpleDescription,
       toDocument,
       toFile,
       toOrganization,
@@ -332,7 +339,11 @@ const c = {
     result.authors = toList('authors', source, toCaver);
     result.children = toList('children', source, toDocument);
     result.files = toList('files', source, toFile);
-    const formattedDescriptions = toList('descriptions', source, toDescription);
+    const formattedDescriptions = toList(
+      'descriptions',
+      source,
+      toSimpleDescription
+    );
 
     // source.descriptions contains both title and descriptions (in .title and .body)
     // Split them in 2 different attributes
@@ -453,7 +464,7 @@ const c = {
 
     // Convert collections
     result.names = toList('names', source, c.toName);
-    result.descriptions = toList('descriptions', source, c.toDescription);
+    result.descriptions = toList('descriptions', source, c.toSimpleDescription);
     result.comments = toList('comments', source, c.toComment);
     result.documents = toList('documents', source, c.toDocument);
     result.histories = toList('histories', source, c.toHistory);
@@ -592,7 +603,7 @@ const c = {
     result.nbEntrances = source['nb entrances']; // from Elasticsearch
 
     // Convert objects
-    const { toCave, toCaver, toDescription, toDocument, toEntrance } =
+    const { toCave, toCaver, toSimpleDescription, toDocument, toEntrance } =
       module.exports;
     result.author =
       source.author instanceof Object ? toCaver(source.author) : source.author;
@@ -603,7 +614,7 @@ const c = {
 
     // Convert collections
     result.entrances = toList('entrances', source, toEntrance);
-    result.descriptions = toList('descriptions', source, toDescription);
+    result.descriptions = toList('descriptions', source, toSimpleDescription);
     result.documents = toList('documents', source, toDocument);
     result.networks = toList('networks', source, toCave);
 


### PR DESCRIPTION
## 🤔 What

Fix #1092 : notification related entity link (entrance of a description, entrance of a location, cave of a history etc.).

## 🤷‍♂️ Why

In the client, when a notification about a description (for example) is displayed, the client doesn't know where to redirect the user when he clicks the notification : there is no "description" page. Instead, the client search a related entity in the notification, such an entrance, and redirects the user to it.

During #1074, the notification converter has been updated. It stopped to return the related entity of a notification. 

## 🔍 How

Create new converters for description, location, comment, rigging and history (simple & complete ones) : 
- simple ones don't return the related entity
- complete ones do

`toNotification` uses `toDescription, toLocation, toRigging, toHistory` while other converters & controllers use `toSimpleDescription, toSimpleLocation, toSimpleRigging, toSimpleHistory`.
