### PR TITLE
feat(massif): remove 2000 length constraint on polygone

### DIFF
--- a/api/models/TMassif.js
+++ b/api/models/TMassif.js
@@ -75,7 +75,6 @@ module.exports = {
       type: 'string',
       allowNull: true,
       columnName: 'geog_polygon',
-      maxLength: 2000,
     },
 
     subscribedCavers: {


### PR DESCRIPTION
## 🤔 What

Remove the obsolete max length contraint on the polygone massif field.
this was useful when the polygone was a KML (string in DB). Now it is stored as a geography with no size limit in DB.