### PR TITLE
improvement(login): caver email always as lowercase

### DIFF
--- a/api/controllers/v1/account/change-email.js
+++ b/api/controllers/v1/account/change-email.js
@@ -31,7 +31,7 @@ module.exports = async (req, res) => {
     await TCaver.updateOne({
       id: req.token.id,
     }).set({
-      mail: req.param('email'),
+      mail: req.param('email').toLowerCase(),
     });
 
     return res.ok();

--- a/api/controllers/v1/account/forgot-password.js
+++ b/api/controllers/v1/account/forgot-password.js
@@ -10,9 +10,9 @@ module.exports = async (req, res) => {
   }
 
   // Get info about the user
-  const userFound = await TCaver.findOne({ mail: emailProvided }).populate(
-    'language'
-  );
+  const userFound = await TCaver.findOne({
+    mail: emailProvided.toLowerCase(),
+  }).populate('language');
   if (!userFound) {
     return res.notFound({
       message: `Caver with email ${emailProvided} not found.`,

--- a/api/controllers/v1/auth/sign-up.js
+++ b/api/controllers/v1/auth/sign-up.js
@@ -12,7 +12,7 @@ module.exports = async (req, res) => {
   if (
     await sails.helpers.checkIfExists.with({
       attributeName: 'mail',
-      attributeValue: req.param('email'),
+      attributeValue: req.param('email').toLowerCase(),
       sailsModel: TCaver,
     })
   ) {
@@ -49,7 +49,7 @@ module.exports = async (req, res) => {
     const newCaver = await TCaver.create({
       dateInscription: new Date(),
       language: '000', // default null language id
-      mail: req.param('email'),
+      mail: req.param('email').toLowerCase(),
       name: req.param('name') === '' ? null : req.param('name'),
       nickname: req.param('nickname'),
       password: await AuthService.createHashedPassword(req.param('password')),

--- a/api/services/AuthService.js
+++ b/api/services/AuthService.js
@@ -29,7 +29,9 @@ async function authenticate(email, password) {
 
   if (!email || !password) return { status: authenticateResult.MISMATCH };
 
-  const user = await TCaver.findOne({ mail: email }).populate('groups');
+  const user = await TCaver.findOne({ mail: email.toLowerCase() }).populate(
+    'groups'
+  );
 
   if (!user) return { status: authenticateResult.MISMATCH };
   if (!user.password?.startsWith('$argon2'))


### PR DESCRIPTION
This is to :
- prevent duplicate email addresses in the t_caver table with different case
- make login easier event if the case of the email provided during login is not the same as the DB.

In addition to this code change, the following Query will need to be run in DB : 

```
update public.t_caver set mail = LOWER(mail);
```

Fix #1154 