### PR TITLE
fix(entrance): use coordinates to set country

### DIFF
--- a/api/controllers/v1/entrance/update.js
+++ b/api/controllers/v1/entrance/update.js
@@ -86,7 +86,7 @@ module.exports = async (req, res) => {
       cleanedData.region = address.region;
       cleanedData.county = address.county;
       cleanedData.city = address.city;
-      cleanedData.id_country = address.id_country;
+      cleanedData.country = address.id_country;
       cleanedData.iso_3166_2 = address.iso_3166_2;
     }
   }

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -201,7 +201,7 @@ module.exports = {
       entranceData.region = address.region;
       entranceData.county = address.county;
       entranceData.city = address.city;
-      entranceData.id_country = address.id_country;
+      entranceData.country = address.id_country;
       entranceData.iso_3166_2 = address.iso_3166_2;
       /* eslint-enable no-param-reassign */
     }


### PR DESCRIPTION
Fix bad naming of the `country` column name with waterline