### PR TITLE
Fix document duplicate display error

### DIFF
--- a/api/controllers/v1/document-duplicate/find.js
+++ b/api/controllers/v1/document-duplicate/find.js
@@ -46,11 +46,11 @@ module.exports = async (req, res) => {
   const duplicateDoc = duplicate.content.document;
   const duplicateDesc = duplicate.content.description;
   let descLang;
-  if (duplicateDesc.documentMainLanguage) {
+  if (duplicateDesc.documentMainLanguage?.id) {
     duplicateDoc.languages = [duplicateDesc.documentMainLanguage.id];
     duplicateDesc.documentMainLanguage = undefined;
   }
-  if (duplicateDesc.titleAndDescriptionLanguage) {
+  if (duplicateDesc.titleAndDescriptionLanguage?.id) {
     descLang = duplicateDesc.titleAndDescriptionLanguage.id;
     duplicateDesc.titleAndDescriptionLanguage = undefined;
   }


### PR DESCRIPTION
Fix document duplicate display error when the column `dc:language` was not present or mistyped during CSV import.

Like the with this [CSV](https://github.com/GrottoCenter/grottocenter-front/files/11289276/test3lignes.EchoKarst.csv)