### PR TITLE
Save and expose the latest contributions

### DIFF
--- a/api/controllers/v1/cave/update.js
+++ b/api/controllers/v1/cave/update.js
@@ -55,16 +55,17 @@ module.exports = async (req, res) => {
     if (newTemperature) updatedFields.temperature = newTemperature;
     if (newIsDiving) updatedFields.isDiving = newIsDiving;
 
-    await TCave.updateOne({ id: caveId }).set(updatedFields);
-
     // Handle name manually
     // Currently, use only one name per cave (even if the model can handle multiple names)
+    // Done before the TCave update so the last_change_cave DB trigger will fetch the last updated name
     await TName.updateOne({
       cave: caveId,
     }).set({
       name: req.param('name')?.text,
       language: req.param('name')?.language,
     });
+
+    await TCave.updateOne({ id: caveId }).set(updatedFields);
 
     const populatedCave = await TCave.findOne(caveId)
       .populate('author')

--- a/api/controllers/v1/change/get-recent.js
+++ b/api/controllers/v1/change/get-recent.js
@@ -1,0 +1,24 @@
+const ControllerService = require('../../../services/ControllerService');
+const RecentChangeService = require('../../../services/RecentChangeService');
+
+module.exports = async (req, res) => {
+  let offset = parseInt(req.param('offset'), 10);
+  if (Number.isNaN(offset)) offset = 0;
+  let limit = parseInt(req.param('limit'), 10);
+  if (Number.isNaN(limit)) limit = 10;
+  const start = offset >= 0 ? offset : offset - limit;
+  const end = offset >= 0 ? offset + limit : offset;
+
+  const changes = await RecentChangeService.getRecent();
+
+  return ControllerService.treat(
+    req,
+    null,
+    { changes: changes.slice(start, end) },
+    {
+      controllerMethod: 'ChangeController.getRecent',
+      notFoundMessage: 'Problem while getting the recent changes',
+    },
+    res
+  );
+};

--- a/api/controllers/v1/massif/create.js
+++ b/api/controllers/v1/massif/create.js
@@ -5,6 +5,7 @@ const ErrorService = require('../../../services/ErrorService');
 const MassifService = require('../../../services/MassifService');
 const NotificationService = require('../../../services/NotificationService');
 const RightService = require('../../../services/RightService');
+const RecentChangeService = require('../../../services/RecentChangeService');
 const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
@@ -117,6 +118,13 @@ module.exports = async (req, res) => {
 
       return newMassifPopulated;
     });
+
+    await RecentChangeService.setNameCreate(
+      'massif',
+      newMassif.id,
+      req.token.id,
+      req.body.name
+    );
 
     await NotificationService.notifySubscribers(
       req,

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -53,6 +53,7 @@ module.exports = async (req, res) => {
         cleanedData.geogPolygon
       );
     }
+    // The name is updated via the /api/v1/names route by the front
     const updatedMassif = await TMassif.updateOne(massifId).set(cleanedData);
     await NameService.setNames([updatedMassif], 'massif');
     await NotificationService.notifySubscribers(

--- a/api/controllers/v1/organization/update.js
+++ b/api/controllers/v1/organization/update.js
@@ -39,6 +39,7 @@ module.exports = async (req, res) => {
 
   const cleanedData = {
     ...GrottoService.getConvertedDataFromClientRequest(req),
+    reviewer: req.token.id,
     id: organizationId,
   };
 
@@ -55,6 +56,7 @@ module.exports = async (req, res) => {
   }
 
   try {
+    // The name is updated via the /api/v1/names route by the front
     const updatedOrganization = await TGrotto.updateOne({
       id: organizationId,
     }).set(cleanedData);

--- a/api/models/TLastChange.js
+++ b/api/models/TLastChange.js
@@ -1,0 +1,52 @@
+module.exports = {
+  tableName: 't_last_change',
+
+  attributes: {
+    entityType: {
+      type: 'string',
+      columnName: 'type_entity',
+      maxLength: 30,
+    },
+
+    typeChange: {
+      type: 'string',
+      columnName: 'type_change',
+      maxLength: 30,
+    },
+
+    dateChange: {
+      type: 'ref',
+      columnType: 'timestamp',
+      columnName: 'date_change',
+    },
+
+    author: {
+      columnName: 'id_author',
+      model: 'TCaver',
+    },
+
+    entityId: {
+      type: 'number',
+      columnName: 'id_entity',
+      columnType: 'int4',
+    },
+
+    entityRelatedType: {
+      type: 'number',
+      columnName: 'type_related_entity',
+      columnType: 'int4',
+    },
+
+    entityRelatedId: {
+      type: 'number',
+      columnName: 'id_related_entity',
+      columnType: 'int4',
+    },
+
+    name: {
+      type: 'string',
+      columnName: 'name',
+      maxLength: 300,
+    },
+  },
+};

--- a/api/services/CaveService.js
+++ b/api/services/CaveService.js
@@ -6,6 +6,7 @@ const {
   NOTIFICATION_ENTITIES,
 } = require('./NotificationService');
 const NotificationService = require('./NotificationService');
+const RecentChangeService = require('./RecentChangeService');
 
 const GET_CUMULATED_LENGTH = `
   SELECT SUM(c.length) as sum_length, COUNT(c.length) as nb_data
@@ -13,7 +14,7 @@ const GET_CUMULATED_LENGTH = `
   JOIN t_cave c ON e.id_cave = c.id
   WHERE c.length IS NOT NULL
   AND c.is_deleted = false
-  AND e.is_deleted = false  
+  AND e.is_deleted = false
 `;
 
 module.exports = {
@@ -73,6 +74,13 @@ module.exports = {
     });
 
     module.exports.setEntrances([res]);
+
+    await RecentChangeService.setNameCreate(
+      'cave',
+      res.id,
+      req.token.id,
+      nameData.name
+    );
 
     await NotificationService.notifySubscribers(
       req,

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -24,6 +24,7 @@ const ElasticsearchService = require('./ElasticsearchService');
 const FileService = require('./FileService');
 const NameService = require('./NameService');
 const NotificationService = require('./NotificationService');
+const RecentChangeService = require('./RecentChangeService');
 const {
   NOTIFICATION_TYPES,
   NOTIFICATION_ENTITIES,
@@ -292,6 +293,7 @@ module.exports = {
       isValidated: false,
       dateValidation: null,
       dateReviewed: new Date(),
+      reviewer: req.token.id,
       modifiedDocJson: jsonData,
     });
 
@@ -360,6 +362,13 @@ module.exports = {
 
       return createdDocument;
     });
+
+    await RecentChangeService.setNameCreate(
+      'document',
+      document.id,
+      req.token.id,
+      langDescData.title
+    );
 
     const populatedDocument = await module.exports.getDocument(
       document.id,

--- a/api/services/EntranceService.js
+++ b/api/services/EntranceService.js
@@ -15,6 +15,7 @@ const ElasticsearchService = require('./ElasticsearchService');
 const NameService = require('./NameService');
 const NotificationService = require('./NotificationService');
 const GeocodingService = require('./GeocodingService');
+const RecentChangeService = require('./RecentChangeService');
 
 const {
   NOTIFICATION_ENTITIES,
@@ -68,7 +69,7 @@ module.exports = {
     }
     return {
       ...reqBodyWithoutId,
-      geology: ramda.propOr('Q35758', 'geology', req.body),
+      geology: req.body.geology ?? 'Q35758',
       isSensitive,
     };
   },
@@ -284,6 +285,13 @@ module.exports = {
           .usingConnection(db);
         return res;
       });
+
+    await RecentChangeService.setNameCreate(
+      'entrance',
+      newEntrancePopulated.id,
+      req.token.id,
+      nameDescLocData.name.text
+    );
 
     // Prepare data for Elasticsearch indexation
     const description =

--- a/api/services/GrottoService.js
+++ b/api/services/GrottoService.js
@@ -5,6 +5,8 @@ const NameService = require('./NameService');
 const NotificationService = require('./NotificationService');
 const DescriptionService = require('./DescriptionService');
 const GeocodingService = require('./GeocodingService');
+const RecentChangeService = require('./RecentChangeService');
+
 const {
   NOTIFICATION_ENTITIES,
   NOTIFICATION_TYPES,
@@ -150,6 +152,13 @@ module.exports = {
       deleted: newOrganizationPopulated.isDeleted,
       tags: ['grotto'],
     });
+
+    await RecentChangeService.setNameCreate(
+      'grotto',
+      newOrganizationPopulated.id,
+      req.token.id,
+      nameData.text
+    );
 
     await NotificationService.notifySubscribers(
       req,

--- a/api/services/RecentChangeService.js
+++ b/api/services/RecentChangeService.js
@@ -1,0 +1,130 @@
+const CommonService = require('./CommonService');
+
+const GROUP_MAX_TIME_DIFF_S = 60 * 60 * 6; // 6 Hours
+
+async function removeOlderChanges() {
+  const query = `DELETE FROM t_last_change WHERE date_change < current_timestamp - interval '1 month';`;
+  await CommonService.query(query);
+}
+
+// When creating a cave, entrance, massif, document or grotto the name is created after the entity
+// So the name is updated afterward
+async function setNameCreate(entityType, entityId, authorId, name) {
+  const query = `
+  UPDATE t_last_change
+  SET name = $1
+  WHERE type_entity = $2 AND type_change = 'create' AND id_entity = $3 AND id_author = $4 AND date_change > current_timestamp - interval '1 minute';
+  `;
+  await CommonService.query(query, [name, entityType, entityId, authorId]);
+}
+
+// To make the change list more relevant we groups change event when they are from the same author and about the same entity
+function groupChanges(changes) {
+  const authorChanges = {};
+  // Grouping order:
+  // - author
+  // - related entity
+  // - time
+  // Change type 'create' or 'restore' have priority over 'update'
+  // Change type 'delete' is never grouped
+
+  const createNewGroupFromChange = (c) => ({
+    date: c.date_change,
+    authorId: c.id_author,
+    author: c.nickname,
+    mainEntityType: c.type_related_entity ?? c.type_entity,
+    mainEntityId: c.id_related_entity ?? c.id_entity,
+    mainAction: c.id_related_entity ? null : c.type_change, // Null in case it is a change on a sub entity
+    subEntityTypes: c.id_related_entity ? [c.type_entity] : [],
+    subAction: c.id_related_entity ? c.type_change : null, // Null when no sub entities
+    name: c.name, // Can be the real entity name or the related entity name
+  });
+
+  const addChangeToExistingGroup = (g, c) => {
+    if (
+      !c.id_related_entity &&
+      g.mainAction === 'update' &&
+      ['create', 'restore'].includes(c.type_change)
+    )
+      g.mainAction = c.type_change; // eslint-disable-line no-param-reassign
+    if (c.id_related_entity && !g.subEntityTypes.includes(c.type_entity))
+      g.subEntityTypes.push(c.type_entity);
+    if (c.id_related_entity && g.subAction !== c.type_change)
+      g.subAction = 'change'; // eslint-disable-line no-param-reassign
+  };
+
+  for (const change of changes) {
+    if (!authorChanges[change.id_author]) {
+      authorChanges[change.id_author] = [createNewGroupFromChange(change)];
+      continue; // eslint-disable-line no-continue
+    }
+
+    const authorsChanges = authorChanges[change.id_author];
+    const previousChangeForThisEntity = authorsChanges.find(
+      (e) =>
+        e.mainEntityId === (change.id_related_entity ?? change.id_entity) &&
+        e.mainEntityType === (change.type_related_entity ?? change.type_entity)
+    );
+
+    if (
+      !previousChangeForThisEntity ||
+      Math.abs(previousChangeForThisEntity.date - change.date_change) >
+        GROUP_MAX_TIME_DIFF_S * 1000 ||
+      change.type_change === 'delete' ||
+      previousChangeForThisEntity.mainAction === 'delete'
+    ) {
+      authorsChanges.unshift(createNewGroupFromChange(change));
+      continue; // eslint-disable-line no-continue
+    }
+    addChangeToExistingGroup(previousChangeForThisEntity, change);
+  }
+
+  const allGroups = Object.values(authorChanges).flat();
+  return allGroups.sort((a, b) => b.date - a.date);
+}
+
+async function getRecent() {
+  // The t_last_change table is populated by trigger on the other main tables
+  const query = `
+  SELECT tbl.*, author.nickname FROM t_last_change tbl
+  LEFT JOIN t_caver author ON tbl.id_author = author.id
+  ORDER BY date_change DESC
+  `;
+  const rep = await CommonService.query(query);
+
+  // When creating/updating a entrance the associated cave is also created/updated (when not part of a network)
+  // As cave changes are duplicate we filter out them
+  const changes = rep.rows.filter((e, i, a) => {
+    if (e.type_entity !== 'cave') return true;
+
+    // Is the cave change is after the entrance change ?
+    if (
+      i < a.length - 2 &&
+      a[i + 1].date_change - e.date_change < 5000 &&
+      a[i + 1].id_author === e.id_author &&
+      a[i + 1].type_entity === 'entrance'
+    )
+      return false;
+
+    // Is the cave change is before the entrance change ?
+    if (
+      i > 0 &&
+      e.date_change - a[i - 1].date_change < 5000 &&
+      a[i - 1].id_author === e.id_author &&
+      a[i - 1].type_entity === 'entrance'
+    )
+      return false;
+
+    return true;
+  });
+
+  // 5% chance to also remove older changes
+  if (Math.random() < 0.05) removeOlderChanges();
+
+  return groupChanges(changes);
+}
+
+module.exports = {
+  getRecent,
+  setNameCreate,
+};

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3082,6 +3082,59 @@ paths:
 
         '403':
           description: You are not authorized to create a document (or entrance).
+
+  '/changes/recent':
+    get:
+      tags:
+        - changes
+      description: Get the latest entity changes on Grottocenter
+      parameters:
+        - name: offset
+          in: query
+          description: The number of changes to skip
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          description: The number of changes to retrieve
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  changes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date:
+                          type: string
+                        authorId:
+                          type: integer
+                        author:
+                          type: string
+                        mainEntityType:
+                          type: string
+                        mainEntityId:
+                          type: integer
+                        subEntityTypes:
+                          type: array
+                          items:
+                            type: string
+                        mainAction:
+                          type: string
+                        subAction:
+                          type: string
+                        name:
+                          type: string
+
 parameters:
   sw_lat:
     name: sw_lat

--- a/config/policies.js
+++ b/config/policies.js
@@ -228,6 +228,9 @@ module.exports.policies = {
   // Swagger (API doc)
   'v1/swagger/get-yaml': true,
 
+  // Changes
+  'v1/change/get-recent': true,
+
   /** *************************************************************************
    *                                                                          *
    * Here's an example of mapping some policies to run before a controller    *

--- a/config/routes.js
+++ b/config/routes.js
@@ -324,6 +324,9 @@ module.exports.routes = {
   'GET /api/v1/locations/:id/snapshots': 'v1/location/get-snapshots',
   'GET /api/v1/riggings/:id/snapshots': 'v1/rigging/get-snapshots',
 
+  // Changes
+  'GET /api/v1/changes/recent': 'v1/change/get-recent',
+
   //  ╦ ╦╔═╗╔╗ ╦ ╦╔═╗╔═╗╦╔═╔═╗
   //  ║║║║╣ ╠╩╗╠═╣║ ║║ ║╠╩╗╚═╗
   //  ╚╩╝╚═╝╚═╝╩ ╩╚═╝╚═╝╩ ╩╚═╝

--- a/sql/0_tables.sql
+++ b/sql/0_tables.sql
@@ -1191,3 +1191,18 @@ CREATE TABLE t_iso3166_2 (
 	name_ro varchar(200) NULL,
 	CONSTRAINT t_iso3166_2_pk PRIMARY KEY (iso)
 );
+
+-- DROP TABLE t_last_change;
+CREATE TABLE t_last_change (
+	-- id serial NOT NULL,
+	type_entity varchar(30) NOT NULL,
+	type_change varchar(30) NOT NULL,
+	date_change timestamp NOT NULL DEFAULT now(),
+	id_author int4 NOT NULL,
+	id_entity int4 NOT NULL,
+	type_related_entity varchar(30) NULL,
+	id_related_entity int4 NULL,
+	name varchar(300) NULL,
+
+	CONSTRAINT t_last_change_t_caver_fk FOREIGN KEY (id_author) REFERENCES t_caver(id)
+);

--- a/sql/0_triggers.sql
+++ b/sql/0_triggers.sql
@@ -22,10 +22,7 @@ new.size_coef := coef;
 return new;
 end;
 $function$;
-CREATE TRIGGER size_coef_insert_update BEFORE
-INSERT
-    OR
-UPDATE ON t_cave for each row execute function calcule_size_coef();
+CREATE OR REPLACE TRIGGER size_coef_insert_update BEFORE INSERT OR UPDATE ON t_cave for each row execute function calcule_size_coef();
 --
 --Procédure d'historisation suite à DELETE déclenchée par le trigger
 ----------------------------------------------------------------------
@@ -108,13 +105,60 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_grotto() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de la grotto associé (dans le cas d'un INSERT le name n'est pas encore créé il sera donc null)
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_grotto = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'grotto',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_grotto BEFORE
-UPDATE ON t_grotto FOR EACH ROW EXECUTE PROCEDURE histo_update_grotto();
+CREATE OR REPLACE TRIGGER histo_update_grotto BEFORE UPDATE ON t_grotto FOR EACH ROW EXECUTE PROCEDURE histo_update_grotto();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_grotto BEFORE DELETE ON t_grotto FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_grotto BEFORE DELETE ON t_grotto FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_grotto BEFORE INSERT OR UPDATE ON t_grotto FOR EACH ROW EXECUTE PROCEDURE change_grotto();
 --
 --
 ------------------------------------------------------------
@@ -153,13 +197,60 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_massif() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom du massif associé (dans le cas d'un INSERT le name n'est pas encore créé il sera donc null)
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_massif = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'massif',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_massif BEFORE
-UPDATE ON t_massif FOR EACH ROW EXECUTE PROCEDURE histo_update_massif();
+CREATE OR REPLACE TRIGGER histo_update_massif BEFORE UPDATE ON t_massif FOR EACH ROW EXECUTE PROCEDURE histo_update_massif();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_massif BEFORE DELETE ON t_massif FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_massif BEFORE DELETE ON t_massif FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_massif BEFORE INSERT OR UPDATE ON t_massif FOR EACH ROW EXECUTE PROCEDURE change_massif();
 --
 --
 ------------------------------------------------------------
@@ -214,13 +305,60 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_cave() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de la cave associée (dans le cas d'un INSERT le name n'est pas encore créé il sera donc null)
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_cave = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'cave',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_cave BEFORE
-UPDATE ON t_cave FOR EACH ROW EXECUTE PROCEDURE histo_update_cave();
+CREATE OR REPLACE TRIGGER histo_update_cave BEFORE UPDATE ON t_cave FOR EACH ROW EXECUTE PROCEDURE histo_update_cave();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_cave BEFORE DELETE ON t_cave FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_cave BEFORE DELETE ON t_cave FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_cave BEFORE INSERT OR UPDATE ON t_cave FOR EACH ROW EXECUTE PROCEDURE change_cave();
 --
 --
 ------------------------------------------------------------
@@ -295,13 +433,60 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_entrance() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de l'entrance associée (dans le cas d'un INSERT le name n'est pas encore créé il sera donc null)
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'entrance',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_entrance BEFORE
-UPDATE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE histo_update_entrance();
+CREATE OR REPLACE TRIGGER histo_update_entrance BEFORE UPDATE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE histo_update_entrance();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_entrance BEFORE DELETE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_entrance BEFORE DELETE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_entrance BEFORE INSERT OR UPDATE ON t_entrance FOR EACH ROW EXECUTE PROCEDURE change_entrance();
 --
 --
 ------------------------------------------------------------
@@ -388,13 +573,61 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_document() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+-- Les changements d'un document ne sont sauvegardé que lorsqu'ils sont validés
+if type_change != '' AND NEW.is_validated = true then
+-- Récupère le nom du document associé (dans le cas d'un INSERT le name n'est pas encore créé il sera donc null)
+SELECT tdesc.title INTO entity_name FROM t_description tdesc WHERE tdesc.id_document = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'document',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_document BEFORE
-UPDATE ON t_document FOR EACH ROW EXECUTE PROCEDURE histo_update_document();
+CREATE OR REPLACE TRIGGER histo_update_document BEFORE UPDATE ON t_document FOR EACH ROW EXECUTE PROCEDURE histo_update_document();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_document BEFORE DELETE ON t_document FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_document BEFORE DELETE ON t_document FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_document BEFORE INSERT OR UPDATE ON t_document FOR EACH ROW EXECUTE PROCEDURE change_document();
 --
 --
 ------------------------------------------------------------
@@ -443,13 +676,64 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_history() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de l'entrance associé
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'history',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_history BEFORE
-UPDATE ON t_history FOR EACH ROW EXECUTE PROCEDURE histo_update_history();
+CREATE OR REPLACE TRIGGER histo_update_history BEFORE UPDATE ON t_history FOR EACH ROW EXECUTE PROCEDURE histo_update_history();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_history BEFORE DELETE ON t_history FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_history BEFORE DELETE ON t_history FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_history BEFORE INSERT OR UPDATE ON t_history FOR EACH ROW EXECUTE PROCEDURE change_history();
 --
 --
 ------------------------------------------------------------
@@ -496,13 +780,64 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_location() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de l'entrance associé
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'location',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_location BEFORE
-UPDATE ON t_location FOR EACH ROW EXECUTE PROCEDURE histo_update_location();
+CREATE OR REPLACE TRIGGER histo_update_location BEFORE UPDATE ON t_location FOR EACH ROW EXECUTE PROCEDURE histo_update_location();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_location BEFORE DELETE ON t_location FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_location BEFORE DELETE ON t_location FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_location BEFORE INSERT OR UPDATE ON t_location FOR EACH ROW EXECUTE PROCEDURE change_location();
 --
 --
 ------------------------------------------------------------
@@ -557,11 +892,11 @@ END;
 $$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_name BEFORE
-UPDATE ON t_name FOR EACH ROW EXECUTE PROCEDURE histo_update_name();
+CREATE OR REPLACE TRIGGER histo_update_name BEFORE UPDATE ON t_name FOR EACH ROW EXECUTE PROCEDURE histo_update_name();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_name BEFORE DELETE ON t_name FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_name BEFORE DELETE ON t_name FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
 --
 --
 ------------------------------------------------------------
@@ -624,13 +959,64 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_comment() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de l'entrance associé
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'comment',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_comment BEFORE
-UPDATE ON t_comment FOR EACH ROW EXECUTE PROCEDURE histo_update_comment();
+CREATE OR REPLACE TRIGGER histo_update_comment BEFORE UPDATE ON t_comment FOR EACH ROW EXECUTE PROCEDURE histo_update_comment();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_comment BEFORE DELETE ON t_comment FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_comment BEFORE DELETE ON t_comment FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_comment BEFORE INSERT OR UPDATE ON t_comment FOR EACH ROW EXECUTE PROCEDURE change_comment();
 --
 --
 ------------------------------------------------------------
@@ -687,13 +1073,78 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_description() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE type_related_entity varchar(20);
+DECLARE id_related_entity int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+-- Les descriptions des documents comptabilisés comme changement car elles correspondent à leur nom
+if type_change != '' AND NEW.id_document is null then
+
+if NEW.id_cave is not null then
+type_related_entity := 'cave';
+id_related_entity := NEW.id_cave;
+elsif NEW.id_entrance is not null then
+type_related_entity := 'entrance';
+id_related_entity := NEW.id_entrance;
+elsif NEW.id_massif is not null then
+type_related_entity := 'massif';
+id_related_entity := NEW.id_massif;
+end if;
+-- Récupère le nom de la cave ou l'entrance ou le massif associé
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND (tname.id_cave = NEW.id_cave OR tname.id_entrance = NEW.id_entrance OR tname.id_massif = NEW.id_massif) LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'description',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_description BEFORE
-UPDATE ON t_description FOR EACH ROW EXECUTE PROCEDURE histo_update_description();
+CREATE OR REPLACE TRIGGER histo_update_description BEFORE UPDATE ON t_description FOR EACH ROW EXECUTE PROCEDURE histo_update_description();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_description BEFORE DELETE ON t_description FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_description BEFORE DELETE ON t_description FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_description BEFORE INSERT OR UPDATE ON t_description FOR EACH ROW EXECUTE PROCEDURE change_description();
 --
 --
 ------------------------------------------------------------
@@ -701,7 +1152,7 @@ CREATE TRIGGER histo_delete_description BEFORE DELETE ON t_description FOR EACH 
 ------------------------------------------------------------
 --Historisation suite à UPDATE déclenchée par le trigger
 --La procédure met aussi à jour date_reviewed
----------------------------------------------------------------------
+-------------------------------------------------------------
 CREATE OR REPLACE FUNCTION histo_update_rigging() RETURNS trigger AS $$
 DECLARE date_r timestamp;
 BEGIN --prise en compte du cas de la première modif d'un enregistrement
@@ -750,10 +1201,61 @@ NEW.date_reviewed := now();
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+--
+--Sauvegarde des derniers changements dans la table t_last_change
+-------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_rigging() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := NEW.id_reviewer;
+elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := NEW.id_reviewer;
+end if;
+if type_change != '' then
+-- Récupère le nom de l'entrance associé
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'rigging',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 --trigger qui exécute l'historisation lors d'un UPDATE
 --------------------------------------------------------
-CREATE TRIGGER histo_update_rigging BEFORE
-UPDATE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE histo_update_rigging();
+CREATE OR REPLACE TRIGGER histo_update_rigging BEFORE UPDATE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE histo_update_rigging();
 --trigger qui exécute l'historisation lors d'un DELETE
 --------------------------------------------------------
-CREATE TRIGGER histo_delete_rigging BEFORE DELETE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+CREATE OR REPLACE TRIGGER histo_delete_rigging BEFORE DELETE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE histo_delete();
+--trigger qui exécute la sauvegarde des derniers changements lors d'un CREATE ou d'un UPDATE
+--------------------------------------------------------
+CREATE OR REPLACE TRIGGER last_change_rigging BEFORE INSERT OR UPDATE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE change_rigging();


### PR DESCRIPTION
Save the latest contributions and add a new endpoint to retrieve them

https://github.com/GrottoCenter/grottocenter-front/issues/384

A new table is created to save the latest changes: `t_last_change`.
This new table is populated using DB triggers on the different entities.
Only the _create_ and _update_ changes are saved, the _delete_ and document validation changes are not saved.
The change for a document is only saved when it is validated

For (sub) entities like `location`, `rigging` or `history` the reference to the related main entities is also saved (entrance or document)
The Name of the entity (or related entity) is also retrieved when the change is made to conserve the name change history

The change list from the database is not returned directly, to be more concise and useful events are grouped together.
To keep the UI clean, at most the 10 recent groups are returned by the API

Each time the recent change list is retrieved, there is 5% chance to also clean changes that are older than a month

> In the production DB the new table should be created and the file `0_triggers.sql` should to be reapplied before merging.

Also fix issues discovered during testing:
- Set the reviewer during an entrance update
- Set the reviewer during an organization update
- Set the reviewer during a document update
- Refactor document multiple validation to only make one SQL update

Used by https://github.com/GrottoCenter/grottocenter-front/pull/906

Future works:
- Better handle bulk import of entities (with grouping or filtering)
- Allow to get the latest changes for only a massif or a country (https://github.com/GrottoCenter/grottocenter-front/issues/382)