### PR TITLE
Update 2_2021_09_26_1_doc_types.sql

### DIFF
--- a/sql/2_2021_09_26_1_doc_types.sql
+++ b/sql/2_2021_09_26_1_doc_types.sql
@@ -20,3 +20,4 @@ INSERT INTO t_type (id,"name","comment",id_parent,is_available,url) VALUES
 	 (18,'Article','An article from a source',12,true,'http://id.loc.gov/vocabulary/marcgt/art'),
 	 (19,'Map','A geographical map',11,true,'http://id.loc.gov/vocabulary/marcgt/map'),
 	 (20,'Authorization To Publish','Document attesting to the authorization to publish other documents under a defined licence',NULL,true,'https://ontology.uis-speleo.org/ontology/#AutorizationToPublish');
+	 (21,'Report','Proceedings, reports or summaries of a conference, study, expedition',NULL,true,'http://id.loc.gov/vocabulary/marcgt/cpb');


### PR DESCRIPTION
Add report doc type

## 🤔 What

Rajout du type de document 'report'

## 🤷‍♂️ Why

Pour disposer d'un type de document plus approprié pour les rapports que "text" qui est trop généraliste ou "book" qui ne convient pas tout a fait

## 🔍 How

Ajout dans la table qui convient
