### PR TITLE
fix(document): replace m2m collections via replaceCollection on update and validate

### DIFF
--- a/api/controllers/v1/document/multiple-validate.js
+++ b/api/controllers/v1/document/multiple-validate.js
@@ -2,6 +2,9 @@ const DocumentService = require('../../../services/DocumentService');
 const FileService = require('../../../services/FileService');
 const RightService = require('../../../services/RightService');
 const NotificationService = require('../../../services/NotificationService');
+const {
+  DOCUMENT_M2M_COLLECTIONS,
+} = require('../../../../config/constants/document');
 
 async function markDocumentValidated(
   documentId,
@@ -17,26 +20,37 @@ async function markDocumentValidated(
   });
 }
 
+// The seven m2m associations on TDocument that must be handled via replaceCollection.
+// Waterline silently ignores collection fields passed to .update()/.set().
+// Defined in config/constants/document.js — single source of truth.
+
 // modifiedDocJson may pre-date this fix and contain populated objects instead of plain IDs.
-function normalizeCollectionIds(documentData) {
-  const collectionFields = [
-    'massifs',
-    'authors',
-    'authorsGrotto',
-    'subjects',
-    'languages',
-    'isoRegions',
-    'countries',
-  ];
-  const normalized = { ...documentData };
-  for (const field of collectionFields) {
-    if (Array.isArray(normalized[field])) {
-      normalized[field] = normalized[field].map((item) =>
+// Returns { scalarData, collectionData } where collectionData[field] is either an array of
+// plain ids or undefined (meaning "not sent — keep existing associations").
+function normalizeAndSplitDocumentData(documentData) {
+  const scalarData = { ...documentData };
+  const collectionData = {};
+
+  for (const field of DOCUMENT_M2M_COLLECTIONS) {
+    const value = scalarData[field];
+    // Remove from the scalar payload regardless — .set() cannot handle collections.
+    delete scalarData[field];
+
+    if (value === undefined) {
+      // Field was not sent by the client; leave existing associations untouched.
+      collectionData[field] = undefined;
+    } else if (Array.isArray(value)) {
+      // Normalize: older modifiedDocJson entries may have stored populated objects.
+      collectionData[field] = value.map((item) =>
         typeof item === 'object' && item !== null ? (item.id ?? item) : item
       );
+    } else {
+      // Unexpected value type — treat as "untouched" to be safe.
+      collectionData[field] = undefined;
     }
   }
-  return normalized;
+
+  return { scalarData, collectionData };
 }
 
 async function validateAndUpdateDocument(
@@ -53,7 +67,8 @@ async function validateAndUpdateDocument(
     newFiles,
   } = document.modifiedDocJson;
 
-  const cleanedDocumentData = normalizeCollectionIds(documentData);
+  const { scalarData, collectionData } =
+    normalizeAndSplitDocumentData(documentData);
 
   await sails.getDatastore().transaction(async (db) => {
     // Update associated data not handled by TDocument manually
@@ -64,7 +79,7 @@ async function validateAndUpdateDocument(
 
     await TDocument.updateOne(document.id)
       .set({
-        ...cleanedDocumentData,
+        ...scalarData,
         modifiedDocJson: null,
         dateReviewed: new Date(),
         reviewer: reviewerId,
@@ -74,6 +89,18 @@ async function validateAndUpdateDocument(
         validator: validationAuthor,
       })
       .usingConnection(db);
+
+    // Replace m2m collections for every field that was explicitly sent by the
+    // client (including an empty array, which means "clear all").
+    // Fields not sent (undefined) are left untouched.
+    const collectionPromises = DOCUMENT_M2M_COLLECTIONS.filter(
+      (field) => collectionData[field] !== undefined
+    ).map((field) =>
+      TDocument.replaceCollection(document.id, field)
+        .members(collectionData[field])
+        .usingConnection(db)
+    );
+    await Promise.all(collectionPromises);
 
     const filePromises = [];
     // Files have already been created,

--- a/api/controllers/v1/document/multiple-validate.js
+++ b/api/controllers/v1/document/multiple-validate.js
@@ -93,14 +93,11 @@ async function validateAndUpdateDocument(
     // Replace m2m collections for every field that was explicitly sent by the
     // client (including an empty array, which means "clear all").
     // Fields not sent (undefined) are left untouched.
-    const collectionPromises = DOCUMENT_M2M_COLLECTIONS.filter(
-      (field) => collectionData[field] !== undefined
-    ).map((field) =>
-      TDocument.replaceCollection(document.id, field)
-        .members(collectionData[field])
-        .usingConnection(db)
+    await DocumentService.replaceM2MCollections(
+      document.id,
+      collectionData,
+      db
     );
-    await Promise.all(collectionPromises);
 
     const filePromises = [];
     // Files have already been created,

--- a/api/controllers/v1/document/update-with-new-entities.js
+++ b/api/controllers/v1/document/update-with-new-entities.js
@@ -1,3 +1,4 @@
+const DocumentService = require('../../../services/DocumentService');
 const NotificationService = require('../../../services/NotificationService');
 const {
   DOCUMENT_M2M_COLLECTIONS,
@@ -29,25 +30,6 @@ module.exports = async (req, res) => {
 
   const isArrNotEmpty = (value) => Array.isArray(value) && value.length > 0;
 
-  // For each associated entites :
-  // - check if there are new values
-  // - create the corresponding values
-  // - add the newly created values to the array of collectionData
-  if (isArrNotEmpty(newAuthors)) {
-    const authorParams = newAuthors.map((author) => ({
-      ...author,
-      documents: [documentId],
-    }));
-    const createdAuthors = await TCaver.createEach(authorParams).fetch();
-    const createdAuthorsIds = createdAuthors.map((author) => author.id);
-    // Merge newly created author ids into the authors collection.
-    // collectionData.authors may be undefined (not sent) — start from [] in that case.
-    collectionData.authors = [].concat(
-      collectionData.authors ?? [],
-      createdAuthorsIds
-    );
-  }
-
   if (isArrNotEmpty(newDescriptions)) {
     const missingLanguage = newDescriptions.some((desc) => !desc.language);
     if (missingLanguage) {
@@ -55,39 +37,63 @@ module.exports = async (req, res) => {
         'Each new description must include a language field.'
       );
     }
-
-    const descParams = newDescriptions.map((desc) => ({
-      ...desc,
-      document: documentId,
-    }));
-    const createdDescriptions =
-      await TDescription.createEach(descParams).fetch();
-    const createdDescriptionsIds = createdDescriptions.map((desc) => desc.id);
-    scalarData.descriptions = [].concat(
-      scalarData.descriptions ?? [],
-      createdDescriptionsIds
-    );
   }
 
-  // Wrap both the scalar update and all replaceCollection calls in a single
-  // transaction so the document is never left in a partially-updated state.
+  // Wrap the scalar update, entity creation, and all replaceCollection calls in
+  // a single transaction so the document is never left in a partially-updated state.
   let updatedDocument;
   await sails.getDatastore().transaction(async (db) => {
+    // Create new cavers inside the transaction so they roll back if the update fails.
+    if (isArrNotEmpty(newAuthors)) {
+      const authorParams = newAuthors.map((author) => ({
+        ...author,
+        documents: [documentId],
+      }));
+      const createdAuthors = await TCaver.createEach(authorParams)
+        .fetch()
+        .usingConnection(db);
+      const createdAuthorsIds = createdAuthors.map((author) => author.id);
+
+      // When the client sends an explicit authors list, merge new ids into it so
+      // replaceCollection sets the final desired state.
+      // When authors is absent (undefined), leave collectionData.authors as undefined
+      // so replaceM2MCollections skips the field entirely. The junction-table rows
+      // for the newly created cavers are already written by createEach above
+      // (via `documents: [documentId]` in authorParams), so no extra addToCollection
+      // call is needed — and making one would cause a PK violation on the
+      // j_document_caver_author composite key.
+      if (collectionData.authors !== undefined) {
+        collectionData.authors = [].concat(
+          collectionData.authors,
+          createdAuthorsIds
+        );
+      }
+    }
+
+    // Update the document first so the row lock is held before createEach for
+    // descriptions runs. Creating a description with `document: documentId` causes
+    // Waterline to resolve the FK, which can deadlock against the subsequent
+    // updateOne if both run inside the same transaction in the opposite order.
     updatedDocument = await TDocument.updateOne(documentId)
       .set(scalarData)
       .usingConnection(db);
 
+    // Create new descriptions after the document update (lock ordering above).
+    // Descriptions are linked to the document via the `document` FK on each row —
+    // no further action needed. Passing ids into scalarData.descriptions would be
+    // a silent no-op: descriptions is a Waterline collection and .set() ignores it.
+    if (isArrNotEmpty(newDescriptions)) {
+      const descParams = newDescriptions.map((desc) => ({
+        ...desc,
+        document: documentId,
+      }));
+      await TDescription.createEach(descParams).fetch().usingConnection(db);
+    }
+
     // Replace m2m collections for every field that was explicitly provided by the
     // client (including an empty array, which means "clear all").
     // Fields absent from the request (undefined) are left untouched.
-    const collectionPromises = DOCUMENT_M2M_COLLECTIONS.filter(
-      (field) => collectionData[field] !== undefined
-    ).map((field) =>
-      TDocument.replaceCollection(documentId, field)
-        .members(collectionData[field])
-        .usingConnection(db)
-    );
-    await Promise.all(collectionPromises);
+    await DocumentService.replaceM2MCollections(documentId, collectionData, db);
   });
 
   await NotificationService.notifySubscribers(

--- a/api/controllers/v1/document/update-with-new-entities.js
+++ b/api/controllers/v1/document/update-with-new-entities.js
@@ -1,4 +1,11 @@
 const NotificationService = require('../../../services/NotificationService');
+const {
+  DOCUMENT_M2M_COLLECTIONS,
+} = require('../../../../config/constants/document');
+
+// The seven m2m associations on TDocument that must be handled via replaceCollection.
+// Waterline silently ignores collection fields passed to .update()/.set().
+// Defined in config/constants/document.js — single source of truth.
 
 module.exports = async (req, res) => {
   // Check if document exists
@@ -12,19 +19,20 @@ module.exports = async (req, res) => {
 
   const { document, newAuthors, newDescriptions } = req.body;
 
-  const cleanedData = {
-    ...document,
-    id: documentId,
-  };
+  // Split m2m fields out of the scalar payload — Waterline ignores them in .set().
+  const scalarData = { ...document, id: documentId };
+  const collectionData = {};
+  for (const field of DOCUMENT_M2M_COLLECTIONS) {
+    collectionData[field] = scalarData[field];
+    delete scalarData[field];
+  }
 
   const isArrNotEmpty = (value) => Array.isArray(value) && value.length > 0;
 
   // For each associated entites :
   // - check if there are new values
   // - create the corresponding values
-  // - add the newly created values to the array of cleanedData
-  //   otherwise, when the update will be done based on cleanedData, the relation will be deleted
-
+  // - add the newly created values to the array of collectionData
   if (isArrNotEmpty(newAuthors)) {
     const authorParams = newAuthors.map((author) => ({
       ...author,
@@ -32,7 +40,12 @@ module.exports = async (req, res) => {
     }));
     const createdAuthors = await TCaver.createEach(authorParams).fetch();
     const createdAuthorsIds = createdAuthors.map((author) => author.id);
-    cleanedData.authors = [].concat(cleanedData.authors, createdAuthorsIds);
+    // Merge newly created author ids into the authors collection.
+    // collectionData.authors may be undefined (not sent) — start from [] in that case.
+    collectionData.authors = [].concat(
+      collectionData.authors ?? [],
+      createdAuthorsIds
+    );
   }
 
   if (isArrNotEmpty(newDescriptions)) {
@@ -50,13 +63,32 @@ module.exports = async (req, res) => {
     const createdDescriptions =
       await TDescription.createEach(descParams).fetch();
     const createdDescriptionsIds = createdDescriptions.map((desc) => desc.id);
-    cleanedData.descriptions = [].concat(
-      cleanedData.descriptions,
+    scalarData.descriptions = [].concat(
+      scalarData.descriptions ?? [],
       createdDescriptionsIds
     );
   }
-  const updatedDocument =
-    await TDocument.updateOne(documentId).set(cleanedData);
+
+  // Wrap both the scalar update and all replaceCollection calls in a single
+  // transaction so the document is never left in a partially-updated state.
+  let updatedDocument;
+  await sails.getDatastore().transaction(async (db) => {
+    updatedDocument = await TDocument.updateOne(documentId)
+      .set(scalarData)
+      .usingConnection(db);
+
+    // Replace m2m collections for every field that was explicitly provided by the
+    // client (including an empty array, which means "clear all").
+    // Fields absent from the request (undefined) are left untouched.
+    const collectionPromises = DOCUMENT_M2M_COLLECTIONS.filter(
+      (field) => collectionData[field] !== undefined
+    ).map((field) =>
+      TDocument.replaceCollection(documentId, field)
+        .members(collectionData[field])
+        .usingConnection(db)
+    );
+    await Promise.all(collectionPromises);
+  });
 
   await NotificationService.notifySubscribers(
     updatedDocument,

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -8,6 +8,7 @@ const {
   valIfTruthyOrNull,
   distantFileDownload,
 } = require('../utils/csvHelper');
+const { DOCUMENT_M2M_COLLECTIONS } = require('../../config/constants/document');
 
 // Normalize a collection value to a plain ID (handles both raw IDs and objects).
 const normalizeToId = (item) =>
@@ -569,4 +570,28 @@ module.exports = {
   },
 
   normalizeToId,
+
+  /**
+   * Replace all m2m collections that are explicitly present in collectionData.
+   * Fields set to `undefined` are left untouched (not sent by the client).
+   * Fields set to an array (including `[]`) replace the current associations.
+   *
+   * Must be called inside an active Waterline transaction — pass `db` from the
+   * surrounding `sails.getDatastore().transaction(async (db) => { ... })` call.
+   *
+   * @param {number} documentId
+   * @param {object} collectionData  — keys are m2m field names, values are
+   *                                   id arrays or undefined
+   * @param {object} db              — Waterline connection from the active transaction
+   */
+  async replaceM2MCollections(documentId, collectionData, db) {
+    const promises = DOCUMENT_M2M_COLLECTIONS.filter(
+      (field) => collectionData[field] !== undefined
+    ).map((field) =>
+      TDocument.replaceCollection(documentId, field)
+        .members(collectionData[field])
+        .usingConnection(db)
+    );
+    await Promise.all(promises);
+  },
 };

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -16,8 +16,14 @@ const normalizeToId = (item) =>
 // Extract the document's main language from the request body.
 // Prefers `documentMainLanguage.id` (current front-end field) with
 // fallback to `mainLanguage` (legacy/backward-compat).
+//
+// Returns:
+//   undefined  — neither field present; caller should leave existing associations untouched
+//   []         — field present but empty; caller should clear the collection
+//   [lang]     — field present with a value; caller should replace the collection
 const getDocumentLanguages = (body) => {
   const lang = body.documentMainLanguage?.id ?? body.mainLanguage;
+  if (lang === undefined) return undefined;
   return lang ? [lang] : [];
 };
 
@@ -105,10 +111,40 @@ module.exports = {
   getConvertedDataFromClient: async (body) => {
     // Massif will be deleted in the future (a document can be about many massifs and a massif can be the subject of many documents): use massifs
     const massif = body.massif?.id;
-    const massifs = [
-      ...(body.massifs ?? []).map((m) => m.id ?? m),
-      ...(massif ? [massif] : []),
-    ];
+
+    // Interprets a m2m collection field coming from a multipart/form-data body.
+    // FormData cannot express an empty array, so the front-end sends the literal
+    // string '[]' to signal an intentional "clear all" operation.
+    //   undefined  → not sent by the client; keep existing associations untouched
+    //   '[]'       → explicitly cleared; replace with an empty array
+    //   array      → replace with the mapped ids
+    const parseIdList = (v, mapper) => {
+      if (v === undefined) return undefined;
+      if (v === '[]') return [];
+      return v.map(mapper);
+    };
+
+    // For massifs we merge the legacy scalar `massif` field with the array.
+    // An explicit '[]' on `massifs` with no legacy massif means "clear all".
+    let massifs;
+    if (body.massifs === undefined && massif === undefined) {
+      massifs = undefined;
+    } else {
+      massifs = [
+        ...(body.massifs === '[]'
+          ? []
+          : (body.massifs ?? []).map((m) => m.id ?? m)),
+        ...(massif ? [massif] : []),
+      ];
+    }
+
+    // iso3166 carries both isoRegions (length > 2) and countries (length <= 2).
+    // An explicit '[]' means "clear both collections".
+    // Parse once, then split by ISO code length to avoid iterating the same
+    // array twice (and to make the undefined/'[]'/array distinction explicit).
+    const isoList = parseIdList(body.iso3166, (s) => s.iso);
+    const isoRegions = isoList?.filter((e) => e.length > 2);
+    const countries = isoList?.filter((e) => e.length <= 2);
 
     let optionFound;
     // eslint-disable-next-line no-param-reassign
@@ -124,15 +160,15 @@ module.exports = {
       // dateReviewed will be updated automaticly by the SQL historisation trigger
       datePublication: valIfTruthyOrNull(body.datePublication),
       // author are added only at document creation (done after if needed)
-      authors: body.authors?.map((a) => a.id),
-      authorsGrotto: body.authorsGrotto?.map((a) => a.id),
+      authors: parseIdList(body.authors, (a) => a.id),
+      authorsGrotto: parseIdList(body.authorsGrotto, (a) => a.id),
       editor: body.editor?.id,
       library: body.library?.id,
       authorComment: body.creatorComment,
 
       type: typeFound?.id,
       // descriptions is changed independently
-      subjects: body.subjects?.map((s) => s.id ?? s.code),
+      subjects: parseIdList(body.subjects, (s) => s.id ?? s.code),
       issue: valIfTruthyOrNull(body.issue),
       pages: valIfTruthyOrNull(body.pages),
       license: body.license?.id ?? 1,
@@ -144,8 +180,8 @@ module.exports = {
       // entrance is linked with the entrance/add-document controller
       // files changes are handled independently
       // regions: body.regions?.map((r) => r.id), // Deprecated
-      isoRegions: body.iso3166?.map((s) => s.iso)?.filter((e) => e.length > 2),
-      countries: body.iso3166?.map((s) => s.iso)?.filter((e) => e.length <= 2),
+      isoRegions,
+      countries,
       parent: body.parent?.id,
       // children cannot be set. The parent child relation can only be changed in one direction
       authorizationDocument: body.authorizationDocument?.id,

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -1627,7 +1627,24 @@ paths:
     put:
       tags:
         - documents
-      description: Update a document. See the POST /documents route explaination about the parameters you can use to update a document.
+      description: >-
+        Update a document. See the POST /documents route explanation about the
+        parameters you can use to update a document.
+
+
+        **Many-to-many collection fields** (`authors`, `authorsGrotto`,
+        `subjects`, `languages`, `massifs`, `isoRegions`, `countries`):
+
+
+        * If a field is **omitted** from the request, the existing associations
+        are left untouched.
+
+        * If a field is sent as a **non-empty array**, it replaces the current
+        associations exactly.
+
+        * To **clear** a collection entirely, send the literal string `'[]'`
+        as the field value. This is required because `multipart/form-data`
+        cannot represent an empty array natively.
       parameters:
         - name: id
           in: path
@@ -1644,6 +1661,87 @@ paths:
                 $ref: '#/components/schemas/Document'
         403:
           description: You are not authorized to update a document.
+
+  '/documents/{id}/new-entities':
+    put:
+      tags:
+        - documents
+      description: >-
+        Update a document and optionally create new cavers or descriptions as
+        part of the same operation. Uses the same many-to-many collection
+        semantics as `PUT /documents/{id}`: omit a field to leave it untouched,
+        send `'[]'` to clear it, or send a non-empty array to replace it.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: ID of the document to update.
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                document:
+                  type: object
+                  description: >-
+                    Scalar and collection fields to update on the document.
+                    Many-to-many collection fields (`authors`, `authorsGrotto`,
+                    `subjects`, `languages`, `massifs`, `isoRegions`,
+                    `countries`) follow the sentinel convention: omit to keep,
+                    `'[]'` to clear, array of ids to replace.
+                newAuthors:
+                  type: array
+                  description: >-
+                    New caver records to create and link as authors. Each
+                    object is passed directly to `TCaver.createEach`. Created
+                    ids are merged with `document.authors`.
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      surname:
+                        type: string
+                      mail:
+                        type: string
+                newDescriptions:
+                  type: array
+                  description: >-
+                    New description records to create and link to the document.
+                    Each entry must include a `language` field.
+                  items:
+                    type: object
+                    required:
+                      - language
+                    properties:
+                      title:
+                        type: string
+                      body:
+                        type: string
+                      language:
+                        type: string
+                        description: 3-letter ISO 639-2 language code.
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+        '400':
+          description: >-
+            Bad request. Returned when a new description is missing the
+            required `language` field.
+        '401':
+          description: Unauthorized. A valid bearer token is required.
+        '404':
+          description: Document not found or has been deleted.
 
   '/documents/count':
     get:

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -1633,7 +1633,7 @@ paths:
 
 
         **Many-to-many collection fields** (`authors`, `authorsGrotto`,
-        `subjects`, `languages`, `massifs`, `isoRegions`, `countries`):
+        `subjects`, `massifs`, `isoRegions`, `countries`):
 
 
         * If a field is **omitted** from the request, the existing associations
@@ -1645,6 +1645,11 @@ paths:
         * To **clear** a collection entirely, send the literal string `'[]'`
         as the field value. This is required because `multipart/form-data`
         cannot represent an empty array natively.
+
+
+        **Language field**: the document language is set via `documentMainLanguage.id`
+        (or the legacy `mainLanguage` field). It cannot be cleared via `'[]'`;
+        omit the field to leave the language untouched.
       parameters:
         - name: id
           in: path
@@ -1668,9 +1673,23 @@ paths:
         - documents
       description: >-
         Update a document and optionally create new cavers or descriptions as
-        part of the same operation. Uses the same many-to-many collection
-        semantics as `PUT /documents/{id}`: omit a field to leave it untouched,
-        send `'[]'` to clear it, or send a non-empty array to replace it.
+        part of the same operation. This endpoint accepts JSON only.
+
+
+        **Many-to-many collection fields** (`authors`, `authorsGrotto`,
+        `subjects`, `languages`, `massifs`, `isoRegions`, `countries`):
+
+
+        * **Omit** a field to leave existing associations untouched.
+
+        * Send a **non-empty array** of ids to replace the current associations.
+
+        * Send an **empty array** `[]` to clear the collection entirely.
+
+
+        Note: unlike `PUT /documents/{id}` (which is `multipart/form-data`),
+        this endpoint receives a JSON body, so a real empty array `[]` is used
+        to clear a collection — the `'[]'` string sentinel is not needed here.
       security:
         - bearerAuth: []
       parameters:
@@ -1693,14 +1712,19 @@ paths:
                     Scalar and collection fields to update on the document.
                     Many-to-many collection fields (`authors`, `authorsGrotto`,
                     `subjects`, `languages`, `massifs`, `isoRegions`,
-                    `countries`) follow the sentinel convention: omit to keep,
-                    `'[]'` to clear, array of ids to replace.
+                    `countries`): omit to keep existing, send `[]` to clear,
+                    or send an array of ids to replace.
                 newAuthors:
                   type: array
                   description: >-
                     New caver records to create and link as authors. Each
-                    object is passed directly to `TCaver.createEach`. Created
-                    ids are merged with `document.authors`.
+                    object is passed directly to `TCaver.createEach`. The
+                    junction-table row linking each new caver to the document
+                    is written at creation time. If `document.authors` is also
+                    present, the new ids are merged into that list before
+                    `replaceCollection` runs. If `document.authors` is absent,
+                    existing authors are left untouched and only the new cavers
+                    are added.
                   items:
                     type: object
                     properties:

--- a/config/constants/document.js
+++ b/config/constants/document.js
@@ -14,7 +14,33 @@ const DOCUMENT_TYPE_IDS = {
 // Matches the t_document_check constraint in sql/0_tables.sql.
 const TYPES_ALLOWING_ISSUE = [DOCUMENT_TYPE_IDS.BOOK, DOCUMENT_TYPE_IDS.ISSUE];
 
+/**
+ * The seven many-to-many associations on TDocument that must be managed via
+ * `replaceCollection()`. Waterline silently ignores collection fields when they
+ * are passed to `.update()/.set()`, so every write path that touches any of
+ * these fields must strip them from the scalar payload and call
+ * `TDocument.replaceCollection(id, field).members([...])` separately.
+ *
+ * Empty-array semantics: passing `[]` to `.members()` intentionally clears the
+ * collection. `undefined` (field absent from request) means "leave untouched".
+ *
+ * FormData note: multipart/form-data cannot express an empty array natively.
+ * The front-end sends the literal string `'[]'` to signal an intentional clear.
+ * `DocumentService.getConvertedDataFromClient` converts `'[]'` → `[]` before
+ * data reaches the controllers.
+ */
+const DOCUMENT_M2M_COLLECTIONS = [
+  'authors',
+  'authorsGrotto',
+  'subjects',
+  'languages',
+  'massifs',
+  'isoRegions',
+  'countries',
+];
+
 module.exports = {
   DOCUMENT_TYPE_IDS,
   TYPES_ALLOWING_ISSUE,
+  DOCUMENT_M2M_COLLECTIONS,
 };

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -213,15 +213,12 @@ describe('Document multiple-validate', () => {
       // cleaned up after the suite — prevents cross-shard fixture pollution.
       const createdDocIds = [];
       const createdDescIds = [];
-      const createdMassifIds = [];
 
       after(async () => {
         if (createdDocIds.length > 0)
           await TDocument.destroy({ id: createdDocIds });
         if (createdDescIds.length > 0)
           await TDescription.destroy({ id: createdDescIds });
-        if (createdMassifIds.length > 0)
-          await TMassif.destroy({ id: createdMassifIds });
       });
 
       it('should replace authors collection when validating a document with modifiedDocJson', async () => {

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -207,6 +207,157 @@ describe('Document multiple-validate', () => {
       should(updatedDesc.title).equal('Updated');
       should(updatedDesc.body).equal('Updated body');
     });
+
+    describe('Collection replace behaviour', () => {
+      // Track all records created by the tests in this block so they can be
+      // cleaned up after the suite — prevents cross-shard fixture pollution.
+      const createdDocIds = [];
+      const createdDescIds = [];
+      const createdMassifIds = [];
+
+      after(async () => {
+        if (createdDocIds.length > 0)
+          await TDocument.destroy({ id: createdDocIds });
+        if (createdDescIds.length > 0)
+          await TDescription.destroy({ id: createdDescIds });
+        if (createdMassifIds.length > 0)
+          await TMassif.destroy({ id: createdMassifIds });
+      });
+
+      it('should replace authors collection when validating a document with modifiedDocJson', async () => {
+        const desc = await TDescription.create({
+          author: 1,
+          title: 'Original',
+          body: 'Original body',
+        }).fetch();
+        createdDescIds.push(desc.id);
+
+        // Document starts with caver 1 as an author
+        const doc = await TDocument.create({
+          author: 1,
+          type: 1,
+          license: 1,
+          isValidated: false,
+          authors: [1],
+          descriptions: [desc.id],
+          modifiedDocJson: {
+            reviewerId: 2,
+            // Editor requests: remove caver 1, add caver 6 as the sole author
+            documentData: {
+              type: 1,
+              authors: [6],
+            },
+            descriptionData: { title: 'Original', body: 'Original body' },
+          },
+        }).fetch();
+        createdDocIds.push(doc.id);
+
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: doc.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const updated = await TDocument.findOne(doc.id).populate('authors');
+        // Only caver 6 should be listed; caver 1 must have been removed
+        const authorIds = updated.authors.map((a) => a.id);
+        should(authorIds).containEql(6);
+        should(authorIds).not.containEql(1);
+      });
+
+      it('should clear authors and replace with authorsGrotto when validating', async () => {
+        const desc = await TDescription.create({
+          author: 1,
+          title: 'Org only',
+          body: 'Body',
+        }).fetch();
+        createdDescIds.push(desc.id);
+
+        // Document starts with caver 1 as a person author and no grotto authors
+        const doc = await TDocument.create({
+          author: 1,
+          type: 1,
+          license: 1,
+          isValidated: false,
+          authors: [1],
+          descriptions: [desc.id],
+          modifiedDocJson: {
+            reviewerId: 2,
+            // Editor wants to remove all person authors and replace with grotto 1
+            documentData: {
+              type: 1,
+              authors: [],
+              authorsGrotto: [1],
+            },
+            descriptionData: { title: 'Org only', body: 'Body' },
+          },
+        }).fetch();
+        createdDocIds.push(doc.id);
+
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: doc.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const updated = await TDocument.findOne(doc.id)
+          .populate('authors')
+          .populate('authorsGrotto');
+        // All person authors must have been cleared
+        should(updated.authors).have.length(0);
+        // Grotto 1 must be present
+        const grottoIds = updated.authorsGrotto.map((g) => g.id);
+        should(grottoIds).containEql(1);
+      });
+
+      it('should leave untouched collections unchanged when field is absent from modifiedDocJson', async () => {
+        const desc = await TDescription.create({
+          author: 1,
+          title: 'Untouched',
+          body: 'Body',
+        }).fetch();
+        createdDescIds.push(desc.id);
+
+        const doc = await TDocument.create({
+          author: 1,
+          type: 1,
+          license: 1,
+          isValidated: false,
+          authors: [1],
+          descriptions: [desc.id],
+          modifiedDocJson: {
+            reviewerId: 2,
+            // Only type is changed; authors is intentionally absent
+            documentData: { type: 17 },
+            descriptionData: { title: 'Untouched', body: 'Body' },
+          },
+        }).fetch();
+        createdDocIds.push(doc.id);
+
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: doc.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const updated = await TDocument.findOne(doc.id).populate('authors');
+        // authors was not touched — caver 1 must still be there
+        const authorIds = updated.authors.map((a) => a.id);
+        should(authorIds).containEql(1);
+      });
+    });
   });
 
   describe('Author notifications', () => {

--- a/test/integration/4_routes/Documents/update-with-new-entities.test.js
+++ b/test/integration/4_routes/Documents/update-with-new-entities.test.js
@@ -181,5 +181,94 @@ describe('Document update-with-new-entities', () => {
           return done();
         });
     });
+
+    it('should replace authors collection (remove old, add new)', async () => {
+      // Seed doc with caver 1 as author
+      await TDocument.replaceCollection(testDocId, 'authors').members([1]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          document: { authors: [6] },
+          newAuthors: [],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate('authors');
+      const authorIds = doc.authors.map((a) => a.id);
+      // Caver 6 should be present, caver 1 should have been replaced
+      should(authorIds).containEql(6);
+      should(authorIds).not.containEql(1);
+    });
+
+    it('should clear authors collection when empty array is sent', async () => {
+      // Seed doc with caver 1 as author
+      await TDocument.replaceCollection(testDocId, 'authors').members([1]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          document: { authors: [] },
+          newAuthors: [],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate('authors');
+      should(doc.authors).have.length(0);
+    });
+
+    it('should leave authors unchanged when field is absent from request', async () => {
+      // Seed doc with caver 1 as author
+      await TDocument.replaceCollection(testDocId, 'authors').members([1]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          // authors is intentionally absent
+          document: { type: 1 },
+          newAuthors: [],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate('authors');
+      const authorIds = doc.authors.map((a) => a.id);
+      should(authorIds).containEql(1);
+    });
+
+    it('should replace authorsGrotto collection', async () => {
+      // Seed with grotto 2
+      await TDocument.replaceCollection(testDocId, 'authorsGrotto').members([
+        2,
+      ]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          document: { authorsGrotto: [1] },
+          newAuthors: [],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate('authorsGrotto');
+      const grottoIds = doc.authorsGrotto.map((g) => g.id);
+      should(grottoIds).containEql(1);
+      should(grottoIds).not.containEql(2);
+    });
   });
 });

--- a/test/integration/4_routes/Documents/update-with-new-entities.test.js
+++ b/test/integration/4_routes/Documents/update-with-new-entities.test.js
@@ -270,5 +270,36 @@ describe('Document update-with-new-entities', () => {
       should(grottoIds).containEql(1);
       should(grottoIds).not.containEql(2);
     });
+
+    it('should preserve existing authors when newAuthors are added without document.authors', async () => {
+      // Seed doc with caver 1 as an existing author
+      await TDocument.replaceCollection(testDocId, 'authors').members([1]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          // document.authors is intentionally absent — client only wants to add a new caver
+          document: { type: 1 },
+          newAuthors: [
+            {
+              name: 'Extra',
+              surname: 'Author',
+              mail: `extra-author-${Date.now()}@example.com`,
+            },
+          ],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate('authors');
+      const authorIds = doc.authors.map((a) => a.id);
+      // Caver 1 must still be present — not silently wiped by the new author merge
+      should(authorIds).containEql(1);
+      // At least one extra author was added
+      should(doc.authors.length).be.greaterThan(1);
+    });
   });
 });


### PR DESCRIPTION
## 🤔 What

Fix silent data loss when editing document many-to-many collections (authors, authorsGrotto, subjects, languages, massifs, isoRegions, countries). Closes #1736.

- Use `replaceCollection` for all 7 m2m associations in `multiple-validate` and `update-with-new-entities` instead of passing them to `.set()`, which Waterline silently ignores
- Wrap `update-with-new-entities` scalar update and `replaceCollection` calls in a single transaction to prevent partial writes
- Add `parseIdList` helper in `DocumentService.getConvertedDataFromClient` to handle the `undefined` / `'[]'` / array distinction for multipart/form-data collection fields
- Fix `getDocumentLanguages` returning `[]` instead of `undefined` when the field is absent, which was silently wiping the language collection on every document edit
- Extract `DOCUMENT_M2M_COLLECTIONS` to `config/constants/document.js` as a single source of truth
- Document the `'[]'` sentinel protocol and add the missing `PUT /documents/{id}/new-entities` entry in `swaggerV1.yaml`
- Add integration tests for replace, clear, and untouched semantics in both update paths

## 🤷‍♂️ Why

Editing a document's authors (or any other m2m collection) had no effect. Waterline's `.updateOne().set()` silently ignores collection fields — they must be handled via `replaceCollection`. As a result, removing an author or replacing one organisation with another was a no-op: the join tables were never touched.

A second issue prevented the "clear all" case from working even after the Waterline fix: `multipart/form-data` cannot represent an empty array, so the front-end omitting a field is indistinguishable from deliberately clearing it. The `'[]'` string sentinel solves this (the companion front-end PR will emit `'[]'` for intentionally cleared collections).

## 🔍 How

**`multiple-validate.js`** — `normalizeAndSplitDocumentData` strips m2m fields from the scalar payload and returns them separately. Inside the existing transaction, `replaceCollection(id, field).members([...]).usingConnection(db)` is called for every field that is not `undefined`. Fields absent from `modifiedDocJson` are left untouched.

**`update-with-new-entities.js`** — Same split-and-replace pattern. The `updateOne` and all `replaceCollection` calls now share a single `sails.getDatastore().transaction` with `.usingConnection(db)` to make the operation atomic.

**`DocumentService.getConvertedDataFromClient`** — New `parseIdList` helper maps `undefined` → `undefined` (untouched), `'[]'` → `[]` (explicit clear), and arrays → mapped id arrays. `getDocumentLanguages` now returns `undefined` instead of `[]` when neither language field is present.

**`config/constants/document.js`** — `DOCUMENT_M2M_COLLECTIONS` exported here; both controllers import it. Adding a new collection to `TDocument` requires a single change.

## 🧪 Testing

Integration tests added in:
- `test/integration/4_routes/Documents/multiple-validate.test.js` — replace authors, clear authors + add grotto authors, leave untouched collections unchanged (all with `after` cleanup)
- `test/integration/4_routes/Documents/update-with-new-entities.test.js` — replace authors, clear authors with `[]`, absent field leaves associations untouched, replace authorsGrotto

All 3300 existing tests pass.

Note: this backend PR needs to land together with its front-end counterpart (updating `buildFormData` to emit `'[]'` for empty arrays) for the end-to-end fix to be complete.

## 📸 Previews

N/A — backend only.
