### PR TITLE
feat(document): index authorsOrganization in Typesense and rename from authorsGrotto

### DIFF
--- a/api/controllers/v1/document/delete.js
+++ b/api/controllers/v1/document/delete.js
@@ -85,7 +85,7 @@ module.exports = async (req, res) => {
       languages: 'j_document_language',
       massifs: 'j_document_massif',
       subjects: 'j_document_subject',
-      authorsGrotto: 'j_document_grotto_author',
+      authorsOrganization: 'j_document_grotto_author',
       authors: 'j_document_caver_author',
     };
 
@@ -130,7 +130,7 @@ module.exports = async (req, res) => {
     await linkedEntitiesDeleteOrMerge('languages');
     await linkedEntitiesDeleteOrMerge('massifs');
     await linkedEntitiesDeleteOrMerge('subjects');
-    await linkedEntitiesDeleteOrMerge('authorsGrotto');
+    await linkedEntitiesDeleteOrMerge('authorsOrganization');
     await linkedEntitiesDeleteOrMerge('authors');
 
     await sails.sendNativeQuery(

--- a/api/dbSync/entities/document.js
+++ b/api/dbSync/entities/document.js
@@ -117,9 +117,21 @@ async function* processRows(source) {
         foreignField: 'id_document',
         rows,
         localField: 'authors',
-        fields: ['c.id', 'c.nickname'],
+        fields: ['c.nickname'],
         where: [],
         join: ['LEFT JOIN t_caver c ON c.id = id_caver'],
+      },
+      {
+        table: 'j_document_grotto_author j',
+        foreignField: 'j.id_document',
+        rows,
+        localField: 'authorsOrganization',
+        fields: ['n.name'],
+        where: [],
+        join: [
+          'LEFT JOIN t_grotto g ON g.id = j.id_grotto',
+          'LEFT JOIN t_name n ON n.id_grotto = g.id AND n.is_main = true',
+        ],
       },
       {
         table: 'j_document_language',
@@ -276,6 +288,12 @@ module.exports = {
         { name: 'subjects.code', type: 'string[]', optional: true },
         {
           name: 'authors.nickname',
+          type: 'string[]',
+          facet: true,
+          optional: true,
+        },
+        {
+          name: 'authorsOrganization.name',
           type: 'string[]',
           facet: true,
           optional: true,

--- a/api/models/TDocument.js
+++ b/api/models/TDocument.js
@@ -147,7 +147,7 @@ module.exports = {
       model: 'TGrotto',
     },
 
-    authorsGrotto: {
+    authorsOrganization: {
       collection: 'TGrotto',
       via: 'document',
       through: 'JDocumentGrottoAuthor',

--- a/api/services/DocumentCSVImportService.js
+++ b/api/services/DocumentCSVImportService.js
@@ -200,7 +200,7 @@ module.exports = {
       author: authorId,
       // authorComment: '', // TODO Add ?
       authors: creatorsCaverId,
-      authorsGrotto: creatorsGrottoId,
+      authorsOrganization: creatorsGrottoId,
       editor: editorId,
       // library: '', // TODO Add ?
 

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -14,6 +14,11 @@ const { DOCUMENT_M2M_COLLECTIONS } = require('../../config/constants/document');
 const normalizeToId = (item) =>
   item != null && typeof item === 'object' ? (item.id ?? item) : item;
 
+// Maps a populated authorsOrganization array to the Typesense-ready shape.
+// Exported so property tests can exercise the actual function rather than a copy.
+const mapAuthorsOrganizationForSearch = (orgs) =>
+  orgs?.map((e) => ({ name: e.names?.[0]?.name })) ?? [];
+
 // Extract the document's main language from the request body.
 // Prefers `documentMainLanguage.id` (current front-end field) with
 // fallback to `mainLanguage` (legacy/backward-compat).
@@ -40,6 +45,7 @@ module.exports = {
     // We prefer to clean them to ensure only clean data remains in the search database.
     const {
       authors,
+      authorsOrganization,
       descriptions,
       subjects,
       countries,
@@ -82,6 +88,7 @@ module.exports = {
       editor: editor && { name: editor.names?.[0]?.name },
       library: library && { name: library.names?.[0]?.name },
       authors: authors?.map((e) => ({ nickname: e.nickname })),
+      authorsOrganization: mapAuthorsOrganizationForSearch(authorsOrganization),
       subjects: subjects?.map((e) => ({ code: e.id })),
       iso3166: [
         ...(countries?.map((e) => ({ iso: e.id, name: e.nativeName })) ?? []),
@@ -162,7 +169,7 @@ module.exports = {
       datePublication: valIfTruthyOrNull(body.datePublication),
       // author are added only at document creation (done after if needed)
       authors: parseIdList(body.authors, (a) => a.id),
-      authorsGrotto: parseIdList(body.authorsGrotto, (a) => a.id),
+      authorsOrganization: parseIdList(body.authorsOrganization, (a) => a.id),
       editor: body.editor?.id,
       library: body.library?.id,
       authorComment: body.creatorComment,
@@ -194,7 +201,7 @@ module.exports = {
       .populate('identifierType')
       .populate('author')
       .populate('authors')
-      .populate('authorsGrotto')
+      .populate('authorsOrganization')
       .populate('reviewer')
       .populate('validator')
       .populate('editor')
@@ -246,7 +253,8 @@ module.exports = {
     const allGrottos = [];
     if (document.library) allGrottos.push(document.library);
     if (document.editor) allGrottos.push(document.editor);
-    if (document.authorsGrotto) allGrottos.push(...document.authorsGrotto);
+    if (document.authorsOrganization)
+      allGrottos.push(...document.authorsOrganization);
     if (allGrottos.length > 0) {
       asyncQueue.push(NameService.setNames(allGrottos, 'grotto'));
     }
@@ -406,7 +414,7 @@ module.exports = {
       identifierType,
       author,
       authors,
-      authorsGrotto,
+      authorsOrganization,
       reviewer,
       editor,
       library,
@@ -435,8 +443,8 @@ module.exports = {
       : null;
     doc.author = author ? await TCaver.findOne(author) : null;
     doc.authors = authors ? await TCaver.find({ id: toIds(authors) }) : [];
-    doc.authorsGrotto = authorsGrotto
-      ? await TGrotto.find({ id: toIds(authorsGrotto) })
+    doc.authorsOrganization = authorsOrganization
+      ? await TGrotto.find({ id: toIds(authorsOrganization) })
       : [];
     doc.reviewer = reviewer ? await TCaver.findOne(reviewer) : null;
     doc.editor = editor ? await TGrotto.findOne(editor) : null;
@@ -570,6 +578,7 @@ module.exports = {
   },
 
   normalizeToId,
+  mapAuthorsOrganizationForSearch,
 
   /**
    * Replace all m2m collections that are explicitly present in collectionData.

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -248,7 +248,7 @@ const c = {
       creatorComment: source.authorComment ?? source.creatorComment ?? null,
       authors: toList('authors', source, c.toSimpleCaver),
       authorsOrganization: toList(
-        'authorsGrotto',
+        'authorsOrganization',
         source,
         c.toSimpleOrganization
       ),
@@ -956,7 +956,6 @@ const c = {
       else if (_type === 'documents') {
         data = c.toDocument(item.document, meta);
         // Strip arrays not needed in search responses
-        delete data.authorsOrganization;
         delete data.files;
         delete data.newFiles;
         delete data.modifiedFiles;

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -1396,6 +1396,16 @@ paths:
               properties:
                 id:
                   type: string
+        - name: authorsOrganization
+          in: query
+          description: Organization(s) (grotto/club) id(s) that authored the document.
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
         - name: datePublication
           in: query
           description: Date on which the document you submit was made public. You can refer to the date indicated on the document.
@@ -1632,7 +1642,7 @@ paths:
         parameters you can use to update a document.
 
 
-        **Many-to-many collection fields** (`authors`, `authorsGrotto`,
+        **Many-to-many collection fields** (`authors`, `authorsOrganization`,
         `subjects`, `massifs`, `isoRegions`, `countries`):
 
 
@@ -1657,6 +1667,16 @@ paths:
           required: true
           schema:
             type: string
+        - name: authorsOrganization
+          in: query
+          description: Organization(s) (grotto/club) id(s) that authored the document.
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
       responses:
         200:
           description: Successful operation
@@ -1676,7 +1696,7 @@ paths:
         part of the same operation. This endpoint accepts JSON only.
 
 
-        **Many-to-many collection fields** (`authors`, `authorsGrotto`,
+        **Many-to-many collection fields** (`authors`, `authorsOrganization`,
         `subjects`, `languages`, `massifs`, `isoRegions`, `countries`):
 
 
@@ -1710,7 +1730,7 @@ paths:
                   type: object
                   description: >-
                     Scalar and collection fields to update on the document.
-                    Many-to-many collection fields (`authors`, `authorsGrotto`,
+                    Many-to-many collection fields (`authors`, `authorsOrganization`,
                     `subjects`, `languages`, `massifs`, `isoRegions`,
                     `countries`): omit to keep existing, send `[]` to clear,
                     or send an array of ids to replace.
@@ -8093,6 +8113,15 @@ components:
           $ref: '#/components/schemas/Document'
         authorComment:
           type: string
+        authorsOrganization:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
         cave:
           $ref: '#/components/schemas/Cave'
         commentsBBSOld:

--- a/config/constants/document.js
+++ b/config/constants/document.js
@@ -31,7 +31,7 @@ const TYPES_ALLOWING_ISSUE = [DOCUMENT_TYPE_IDS.BOOK, DOCUMENT_TYPE_IDS.ISSUE];
  */
 const DOCUMENT_M2M_COLLECTIONS = [
   'authors',
-  'authorsGrotto',
+  'authorsOrganization',
   'subjects',
   'languages',
   'massifs',

--- a/sql/9_18_2026_08_04_rename_j_document_grotto_author_fk.sql
+++ b/sql/9_18_2026_08_04_rename_j_document_grotto_author_fk.sql
@@ -1,0 +1,20 @@
+\c grottoce;
+
+-- =============================================================================
+-- Rename FK constraint on j_document_grotto_author (Item D)
+-- =============================================================================
+-- The old name j_document_grotto_author_t_caver_fk was wrong: the FK references
+-- t_grotto, not t_caver. This is a cosmetic correction with no functional impact.
+-- =============================================================================
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'j_document_grotto_author_t_caver_fk'
+  ) THEN
+    ALTER TABLE j_document_grotto_author
+      RENAME CONSTRAINT j_document_grotto_author_t_caver_fk
+      TO j_document_grotto_author_t_grotto_fk;
+  END IF;
+END $$;

--- a/test/integration/1_services/DocumentService.property.test.js
+++ b/test/integration/1_services/DocumentService.property.test.js
@@ -1,0 +1,43 @@
+const should = require('should');
+const fc = require('fast-check');
+const {
+  mapAuthorsOrganizationForSearch,
+} = require('../../../api/services/DocumentService');
+
+describe('DocumentService - Property: updateInSearch authorsOrganization mapping invariant', () => {
+  it('should map each organization to its first name entry', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            names: fc.array(fc.record({ name: fc.string() }), { minLength: 1 }),
+          })
+        ),
+        (orgArray) => {
+          const result = mapAuthorsOrganizationForSearch(orgArray);
+          should(result).be.an.Array();
+          should(result).have.length(orgArray.length);
+          result.forEach((item, i) => {
+            should(item.name).equal(orgArray[i].names[0].name);
+          });
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('should return an empty array for empty input', () => {
+    const result = mapAuthorsOrganizationForSearch([]);
+    should(result).be.an.Array();
+    should(result).have.length(0);
+  });
+
+  it('should confirm ?? [] fallback is necessary: empty names array yields undefined name', () => {
+    // e.names?.[0]?.name is undefined when names is empty — this documents why
+    // the ?? [] fallback in mapAuthorsOrganizationForSearch is needed to avoid
+    // emitting null to Typesense for a string[] field.
+    const org = { names: [] };
+    const name = org.names?.[0]?.name;
+    should(name).be.undefined();
+  });
+});

--- a/test/integration/1_services/DocumentService.test.js
+++ b/test/integration/1_services/DocumentService.test.js
@@ -210,15 +210,23 @@ describe('DocumentService', () => {
     it('should handle authors and organizations', async () => {
       const body = {
         authors: [{ id: 1 }, { id: 2 }],
-        authorsGrotto: [{ id: 1 }],
+        authorsOrganization: [{ id: 1 }],
         editor: { id: 1 },
         library: { id: 2 },
       };
       const result = await DocumentService.getConvertedDataFromClient(body);
       should(result.authors).eql([1, 2]);
-      should(result.authorsGrotto).eql([1]);
+      should(result.authorsOrganization).eql([1]);
       should(result.editor).equal(1);
       should(result.library).equal(2);
+    });
+
+    it('should map authorsOrganization ids from objects', async () => {
+      const body = {
+        authorsOrganization: [{ id: 1 }, { id: 2 }],
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      should(result.authorsOrganization).eql([1, 2]);
     });
 
     it('should handle subjects and iso3166', async () => {
@@ -553,7 +561,7 @@ describe('DocumentService', () => {
         .populate('massifs')
         .populate('library')
         .populate('editor')
-        .populate('authorsGrotto');
+        .populate('authorsOrganization');
 
       const result =
         await DocumentService.populateFullDocumentSubEntities(document);
@@ -571,7 +579,7 @@ describe('DocumentService', () => {
         .populate('massifs')
         .populate('library')
         .populate('editor')
-        .populate('authorsGrotto');
+        .populate('authorsOrganization');
 
       const result =
         await DocumentService.populateFullDocumentSubEntities(document);
@@ -589,7 +597,7 @@ describe('DocumentService', () => {
         .populate('massifs')
         .populate('library')
         .populate('editor')
-        .populate('authorsGrotto');
+        .populate('authorsOrganization');
 
       document.parent = 1;
       const result =

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -266,7 +266,7 @@ describe('Document multiple-validate', () => {
         should(authorIds).not.containEql(1);
       });
 
-      it('should clear authors and replace with authorsGrotto when validating', async () => {
+      it('should clear authors and replace with authorsOrganization when validating', async () => {
         const desc = await TDescription.create({
           author: 1,
           title: 'Org only',
@@ -288,7 +288,7 @@ describe('Document multiple-validate', () => {
             documentData: {
               type: 1,
               authors: [],
-              authorsGrotto: [1],
+              authorsOrganization: [1],
             },
             descriptionData: { title: 'Org only', body: 'Body' },
           },
@@ -307,11 +307,11 @@ describe('Document multiple-validate', () => {
 
         const updated = await TDocument.findOne(doc.id)
           .populate('authors')
-          .populate('authorsGrotto');
+          .populate('authorsOrganization');
         // All person authors must have been cleared
         should(updated.authors).have.length(0);
         // Grotto 1 must be present
-        const grottoIds = updated.authorsGrotto.map((g) => g.id);
+        const grottoIds = updated.authorsOrganization.map((g) => g.id);
         should(grottoIds).containEql(1);
       });
 

--- a/test/integration/4_routes/Documents/update-with-new-entities.test.js
+++ b/test/integration/4_routes/Documents/update-with-new-entities.test.js
@@ -247,16 +247,17 @@ describe('Document update-with-new-entities', () => {
       should(authorIds).containEql(1);
     });
 
-    it('should replace authorsGrotto collection', async () => {
+    it('should replace authorsOrganization collection', async () => {
       // Seed with grotto 2
-      await TDocument.replaceCollection(testDocId, 'authorsGrotto').members([
-        2,
-      ]);
+      await TDocument.replaceCollection(
+        testDocId,
+        'authorsOrganization'
+      ).members([2]);
 
       await supertest(sails.hooks.http.app)
         .put(`/api/v1/documents/${testDocId}/new-entities`)
         .send({
-          document: { authorsGrotto: [1] },
+          document: { authorsOrganization: [1] },
           newAuthors: [],
           newDescriptions: [],
         })
@@ -265,8 +266,39 @@ describe('Document update-with-new-entities', () => {
         .set('Accept', 'application/json')
         .expect(200);
 
-      const doc = await TDocument.findOne(testDocId).populate('authorsGrotto');
-      const grottoIds = doc.authorsGrotto.map((g) => g.id);
+      const doc = await TDocument.findOne(testDocId).populate(
+        'authorsOrganization'
+      );
+      const grottoIds = doc.authorsOrganization.map((g) => g.id);
+      should(grottoIds).containEql(1);
+      should(grottoIds).not.containEql(2);
+    });
+
+    it('should ignore stale authorsGrotto field sent by old clients', async () => {
+      // Seed with grotto 1 as an existing org author
+      await TDocument.replaceCollection(
+        testDocId,
+        'authorsOrganization'
+      ).members([1]);
+
+      await supertest(sails.hooks.http.app)
+        .put(`/api/v1/documents/${testDocId}/new-entities`)
+        .send({
+          // stale client sends old field name — must have no effect
+          document: { authorsGrotto: [2] },
+          newAuthors: [],
+          newDescriptions: [],
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const doc = await TDocument.findOne(testDocId).populate(
+        'authorsOrganization'
+      );
+      const grottoIds = doc.authorsOrganization.map((g) => g.id);
+      // grotto 1 must be untouched — authorsGrotto was silently ignored
       should(grottoIds).containEql(1);
       should(grottoIds).not.containEql(2);
     });

--- a/test/integration/4_routes/Search/advanced-search-document-authors-organization.test.js
+++ b/test/integration/4_routes/Search/advanced-search-document-authors-organization.test.js
@@ -1,0 +1,118 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+/**
+ * Integration tests — authorsOrganization field is preserved in advanced-search
+ * results for documents.
+ *
+ * Validates Requirements 2.1, 2.2, 6.4 — Design Property 2.
+ *
+ * These are conventional it() tests with supertest. HTTP round-trips must NOT
+ * run inside fc.assert loops (causes socket hang-ups under load).
+ */
+describe('Advanced search — document authorsOrganization field in results', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  /**
+   * Case 1 — field present:
+   * When the Typesense hit contains authorsOrganization, the converter (toDocument
+   * via toSearchResult) must retain it in the response payload.
+   *
+   * Validates: Requirements 2.1, 6.4
+   */
+  it('returns authorsOrganization in results when the field is present in the Typesense hit', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        {
+          document: {
+            id: '1',
+            creatorId: 1,
+            creator: 'TestAuthor',
+            type: 'Article',
+            dateInscription: 1700000000000,
+            authorsOrganization: [
+              { name: 'Société méridionale de spéléologie' },
+            ],
+          },
+          highlight: {},
+        },
+      ],
+      found: 1,
+      out_of: 1,
+      page: 1,
+      request_params: { collection_name: 'documents_1' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'documents' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body.results).be.an.Array().with.lengthOf(1);
+    should(res.body.results[0]).have.property('authorsOrganization');
+    should(res.body.results[0].authorsOrganization)
+      .be.an.Array()
+      .with.lengthOf(1);
+    should(res.body.results[0].authorsOrganization[0]).have.property(
+      'name',
+      'Société méridionale de spéléologie'
+    );
+  });
+
+  /**
+   * Case 2 — field absent:
+   * When the Typesense hit does not contain authorsOrganization, toList returns []
+   * (no default injection of non-empty values). The response must not contain a
+   * non-empty authorsOrganization array.
+   *
+   * Note: toDocument always emits authorsOrganization via toList, which returns []
+   * when the source field is absent. An empty array is acceptable — it confirms no
+   * default content was injected.
+   *
+   * Validates: Requirements 2.2
+   */
+  it('returns an empty authorsOrganization array when the field is absent from the Typesense hit', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        {
+          document: {
+            id: '2',
+            creatorId: 1,
+            creator: 'TestAuthor',
+            type: 'Article',
+            dateInscription: 1700000000000,
+            // authorsOrganization intentionally omitted
+          },
+          highlight: {},
+        },
+      ],
+      found: 1,
+      out_of: 1,
+      page: 1,
+      request_params: { collection_name: 'documents_1' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'documents' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body.results).be.an.Array().with.lengthOf(1);
+    // toList returns [] when the source field is absent — no content is injected
+    should(res.body.results[0].authorsOrganization).eql([]);
+  });
+});


### PR DESCRIPTION
## 🤔 What

- Rename the Waterline attribute `authorsGrotto` → `authorsOrganization` on `TDocument`, and update every reference across services, controllers, CSV importer, converters, constants, tests, and Swagger (issues #1729 item E, #1745)
- Index `authorsOrganization` in Typesense — incremental sync via `DocumentService.updateInSearch` and full-reindex via `api/dbSync/entities/document.js` (issue #1729 item A)
- Expose `authorsOrganization` in advanced-search response payloads by removing the `delete data.authorsOrganization` line from `toSearchResult` (issue #1729 item A, #1745)
- Add a SQL migration to rename the misnamed FK constraint `j_document_grotto_author_t_caver_fk` → `j_document_grotto_author_t_grotto_fk` (issue #1729 item D)
- Update Swagger: `authorsOrganization` in the `Document` response schema and POST/PUT request body parameters

Closes items A, D, E from #1729. Remaining items B, C, F are tracked in that issue.

## 🤷‍♂️ Why

The field was internally named `authorsGrotto` (after the `t_grotto` table) while the public API and the product domain use "organization". This asymmetry made the codebase inconsistent and the field was never indexed in Typesense, meaning organization authors were invisible in search results and the Author column was blank in the document results table.

## 🔍 How

**Rename:** One-line change in `TDocument.js` plus a mechanical find-and-replace across all files that referenced `authorsGrotto`. The junction table (`j_document_grotto_author`) and the `JDocumentGrottoAuthor` model are untouched — only the Waterline attribute name and all code referencing it change.

**Typesense indexing:**
- `updateInSearch` now destructures `authorsOrganization` from the populated document and maps each grotto to `{ name: e.names?.[0]?.name }`. The `?? []` fallback ensures Typesense never receives `null` for a `string[]` field.
- `dbSync/entities/document.js` gets a new join block on `j_document_grotto_author` → `t_grotto` → `t_name` (using `n.is_main = true`) and a new schema field `authorsOrganization.name` (`string[]`, `facet: true`, `optional: true`).

**Search results:** removing `delete data.authorsOrganization` from `toSearchResult` in `converters.js` is the entire implementation of exposing the field.

**SQL migration:** wrapped in a `DO $$ BEGIN IF EXISTS ... END $$` block so it is idempotent and matches the project convention.

**Tests:**
- Updated all existing `authorsGrotto` references in `DocumentService.test.js` and route tests
- New property test (`DocumentService.property.test.js`) for the `updateInSearch` mapping invariant using `fast-check`
- New integration test (`advanced-search-document-authors-organization.test.js`) stubbing `SearchService.collectionSearch` to verify the field survives `toSearchResult`
- New test in `update-with-new-entities.test.js` asserting stale clients sending `authorsGrotto` have no effect

## 🧪 Testing

After merging and deploying, a full Typesense reindex is required to make **existing** documents with organization authors searchable (and to fix the null org-author names visible in the validation page):

```bash
node api/dbSync
```

Incremental sync covers only documents validated/restored after the deploy.

## 📸 Previews

N/A — backend-only change.