### PR TITLE
fix(massif): fix stale materialized views and broken statistics endpoint

### DIFF
--- a/api/controllers/v1/country/get-statistics.js
+++ b/api/controllers/v1/country/get-statistics.js
@@ -2,77 +2,90 @@ const ControllerService = require('../../../services/ControllerService');
 const StatisticsCountryService = require('../../../services/StatisticsCountryService');
 
 module.exports = async (req, res) => {
-  // Check if the country id matches with a country in our view
   const countryId = req.params.id;
-  const country = await StatisticsCountryService.isCountryInView(countryId);
-  if (!country) {
-    return res.notFound({ message: `Country with id ${countryId} not found.` });
+
+  try {
+    // Existence check against the real table, not the materialized view.
+    // A country with no cached stats (stale/empty view) is not "not found".
+    const country = await TCountry.findOne({ id: countryId });
+    if (!country) {
+      return res.notFound({
+        message: `Country with id ${countryId} not found.`,
+      });
+    }
+
+    const [
+      nbMassifs,
+      nbCaves,
+      nbNetworks,
+      caveWithMaxDepth,
+      caveWithMaxLength,
+      nbCavesWhichAreDiving,
+      avgDepthAndLength,
+      totalLength,
+    ] = await Promise.all([
+      StatisticsCountryService.getNbMassifsInCountry(countryId),
+      StatisticsCountryService.getNbCavesInCountry(countryId),
+      StatisticsCountryService.getNbNetworksInCountry(countryId),
+      StatisticsCountryService.getCaveWithMaxDepthInCountry(countryId),
+      StatisticsCountryService.getCaveWithMaxLengthInCountry(countryId),
+      StatisticsCountryService.getNbCavesWhichAreDivingInCountry(countryId),
+      StatisticsCountryService.getAvgDepthAndLengthInCountry(countryId),
+      StatisticsCountryService.getTotalLength(countryId),
+    ]);
+
+    const data = {
+      nb_massifs:
+        nbMassifs?.nb_massifs == null
+          ? null
+          : Number.parseInt(nbMassifs.nb_massifs, 10),
+      nb_caves:
+        nbCaves?.nb_caves == null
+          ? null
+          : Number.parseInt(nbCaves.nb_caves, 10),
+      nb_networks:
+        nbNetworks?.nb_networks == null
+          ? null
+          : Number.parseInt(nbNetworks.nb_networks, 10),
+      cave_with_max_depth: caveWithMaxDepth,
+      cave_with_max_length: caveWithMaxLength,
+      diving_caves:
+        nbCavesWhichAreDiving?.nb_diving_cave == null
+          ? null
+          : Number.parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
+      avg: {
+        avg_depth:
+          avgDepthAndLength?.avg_depth == null
+            ? null
+            : Number.parseInt(avgDepthAndLength.avg_depth, 10),
+        avg_length:
+          avgDepthAndLength?.avg_length == null
+            ? null
+            : Number.parseInt(avgDepthAndLength.avg_length, 10),
+      },
+      total_length: {
+        value:
+          totalLength?.value == null
+            ? null
+            : Number.parseInt(totalLength.value, 10),
+        nb_data:
+          totalLength?.nb_data == null
+            ? null
+            : Number.parseInt(totalLength.nb_data, 10),
+      },
+    };
+
+    return ControllerService.treat(
+      req,
+      null,
+      data,
+      { controllerMethod: 'CountryController.get-statistics' },
+      res
+    );
+  } catch (err) {
+    sails.log.error(err);
+    return res.serverError(
+      'An internal error occurred when getting country statistics'
+    );
   }
-
-  const [
-    nbMassifs,
-    nbCaves,
-    nbNetworks,
-    caveWithMaxDepth,
-    caveWithMaxLength,
-    nbCavesWhichAreDiving,
-    avgDepthAndLength,
-    totalLength,
-  ] = await Promise.all([
-    StatisticsCountryService.getNbMassifsInCountry(countryId),
-    StatisticsCountryService.getNbCavesInCountry(countryId),
-    StatisticsCountryService.getNbNetworksInCountry(countryId),
-    StatisticsCountryService.getCaveWithMaxDepthInCountry(countryId),
-    StatisticsCountryService.getCaveWithMaxLengthInCountry(countryId),
-    StatisticsCountryService.getNbCavesWhichAreDivingInCountry(countryId),
-    StatisticsCountryService.getAvgDepthAndLengthInCountry(countryId),
-    StatisticsCountryService.getTotalLength(countryId),
-  ]);
-
-  const data = {
-    nb_massifs:
-      nbMassifs.nb_massifs === null
-        ? null
-        : Number.parseInt(nbMassifs.nb_massifs, 10),
-    nb_caves:
-      nbCaves.nb_caves === null ? null : Number.parseInt(nbCaves.nb_caves, 10),
-    nb_networks:
-      nbNetworks.nb_networks === null
-        ? null
-        : Number.parseInt(nbNetworks.nb_networks, 10),
-    cave_with_max_depth: caveWithMaxDepth,
-    cave_with_max_length: caveWithMaxLength,
-    diving_caves:
-      nbCavesWhichAreDiving.nb_diving_cave === null
-        ? null
-        : Number.parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
-    avg: {
-      avg_depth:
-        avgDepthAndLength.avg_depth === null
-          ? null
-          : Number.parseInt(avgDepthAndLength.avg_depth, 10),
-      avg_length:
-        avgDepthAndLength.avg_length === null
-          ? null
-          : Number.parseInt(avgDepthAndLength.avg_length, 10),
-    },
-    total_length: {
-      value:
-        totalLength.value === null
-          ? null
-          : Number.parseInt(totalLength.value, 10),
-      nb_data:
-        totalLength.nb_data === null
-          ? null
-          : Number.parseInt(totalLength.nb_data, 10),
-    },
-  };
-
-  return ControllerService.treat(
-    req,
-    null,
-    data,
-    { controllerMethod: 'CountryController.get-statistics' },
-    res
-  );
 };

--- a/api/controllers/v1/massif/get-statistics.js
+++ b/api/controllers/v1/massif/get-statistics.js
@@ -2,7 +2,13 @@ const ControllerService = require('../../../services/ControllerService');
 const StatisticsMassifService = require('../../../services/StatisticsMassifService');
 
 module.exports = async (req, res) => {
-  const massifId = req.params.id;
+  const massifId = Number(req.params.id);
+
+  // Guard against NaN, floats, zero, and negatives — all of which make Waterline throw
+  // E_INVALID_PK_VALUE rather than returning null, which would land in the catch as a 500.
+  if (!Number.isSafeInteger(massifId) || massifId <= 0) {
+    return res.notFound({ message: `Massif of id ${req.params.id} not found` });
+  }
 
   try {
     // Existence check against the real table, not the materialized view.
@@ -35,30 +41,34 @@ module.exports = async (req, res) => {
     // if the value is null, we return null
     const data = {
       nb_caves:
-        nbCaves?.nb_caves == null ? null : parseInt(nbCaves.nb_caves, 10),
+        nbCaves?.nb_caves == null
+          ? null
+          : Number.parseInt(nbCaves.nb_caves, 10),
       nb_networks:
         nbNetworks?.nb_networks == null
           ? null
-          : parseInt(nbNetworks.nb_networks, 10),
+          : Number.parseInt(nbNetworks.nb_networks, 10),
       cave_with_max_depth: caveWithMaxDepth,
       cave_with_max_length: caveWithMaxLength,
       diving_caves:
         nbCavesWhichAreDiving?.nb_diving_cave == null
           ? null
-          : parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
+          : Number.parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
       avg: {
         avg_depth:
           avgDepthAndLength?.avg_depth == null
             ? null
-            : parseInt(avgDepthAndLength.avg_depth, 10),
+            : Number.parseInt(avgDepthAndLength.avg_depth, 10),
         avg_length:
           avgDepthAndLength?.avg_length == null
             ? null
-            : parseInt(avgDepthAndLength.avg_length, 10),
+            : Number.parseInt(avgDepthAndLength.avg_length, 10),
       },
       total_length: {
         value:
-          totalLength?.value == null ? null : parseInt(totalLength.value, 10),
+          totalLength?.value == null
+            ? null
+            : Number.parseInt(totalLength.value, 10),
         nb_data:
           totalLength?.nb_data == null
             ? null
@@ -74,12 +84,9 @@ module.exports = async (req, res) => {
       res
     );
   } catch (err) {
-    return ControllerService.treat(
-      req,
-      err,
-      null,
-      { controllerMethod: 'MassifController.get-statistics' },
-      res
+    sails.log.error(err);
+    return res.serverError(
+      'An internal error occurred when getting massif statistics'
     );
   }
 };

--- a/api/controllers/v1/massif/get-statistics.js
+++ b/api/controllers/v1/massif/get-statistics.js
@@ -2,69 +2,84 @@ const ControllerService = require('../../../services/ControllerService');
 const StatisticsMassifService = require('../../../services/StatisticsMassifService');
 
 module.exports = async (req, res) => {
-  // Check if the massif id matches with a massif in our view
   const massifId = req.params.id;
-  const massif = await StatisticsMassifService.isMassifInView(massifId);
-  if (!massif) {
-    return res.notFound({ message: `Massif of id ${massifId} not found` });
-  }
 
-  // Launching all requests at the same time
-  const [
-    nbCaves,
-    nbNetworks,
-    caveWithMaxDepth,
-    caveWithMaxLength,
-    nbCavesWhichAreDiving,
-    avgDepthAndLength,
-    totalLength,
-  ] = await Promise.all([
-    StatisticsMassifService.getNbCavesInMassif(massifId),
-    StatisticsMassifService.getNbNetworksInMassif(massifId),
-    StatisticsMassifService.getCaveWithMaxDepthInMassif(massifId),
-    StatisticsMassifService.getCaveWithMaxLengthInMassif(massifId),
-    StatisticsMassifService.getNbCavesWhichAreDivingInMassif(massifId),
-    StatisticsMassifService.getAvgDepthAndLengthInMassif(massifId),
-    StatisticsMassifService.getTotalLength(massifId),
-  ]);
-  // to avoid that the function parseInt returns NaN when the value is null, we test the value before
-  // if the value is null, we return null
-  const data = {
-    nb_caves: nbCaves.nb_caves === null ? null : parseInt(nbCaves.nb_caves, 10),
-    nb_networks:
-      nbNetworks.nb_networks === null
-        ? null
-        : parseInt(nbNetworks.nb_networks, 10),
-    cave_with_max_depth: caveWithMaxDepth,
-    cave_with_max_length: caveWithMaxLength,
-    diving_caves:
-      nbCavesWhichAreDiving.nb_diving_cave === null
-        ? null
-        : parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
-    avg: {
-      avg_depth:
-        avgDepthAndLength.avg_depth === null
+  try {
+    // Existence check against the real table, not the materialized view.
+    // A massif with no cached stats (stale/empty view) is not "not found".
+    const massif = await TMassif.findOne({ id: massifId, isDeleted: false });
+    if (!massif) {
+      return res.notFound({ message: `Massif of id ${massifId} not found` });
+    }
+
+    // Launching all requests at the same time
+    const [
+      nbCaves,
+      nbNetworks,
+      caveWithMaxDepth,
+      caveWithMaxLength,
+      nbCavesWhichAreDiving,
+      avgDepthAndLength,
+      totalLength,
+    ] = await Promise.all([
+      StatisticsMassifService.getNbCavesInMassif(massifId),
+      StatisticsMassifService.getNbNetworksInMassif(massifId),
+      StatisticsMassifService.getCaveWithMaxDepthInMassif(massifId),
+      StatisticsMassifService.getCaveWithMaxLengthInMassif(massifId),
+      StatisticsMassifService.getNbCavesWhichAreDivingInMassif(massifId),
+      StatisticsMassifService.getAvgDepthAndLengthInMassif(massifId),
+      StatisticsMassifService.getTotalLength(massifId),
+    ]);
+
+    // to avoid that the function parseInt returns NaN when the value is null, we test the value before
+    // if the value is null, we return null
+    const data = {
+      nb_caves:
+        nbCaves?.nb_caves == null ? null : parseInt(nbCaves.nb_caves, 10),
+      nb_networks:
+        nbNetworks?.nb_networks == null
           ? null
-          : parseInt(avgDepthAndLength.avg_depth, 10),
-      avg_length:
-        avgDepthAndLength.avg_length === null
+          : parseInt(nbNetworks.nb_networks, 10),
+      cave_with_max_depth: caveWithMaxDepth,
+      cave_with_max_length: caveWithMaxLength,
+      diving_caves:
+        nbCavesWhichAreDiving?.nb_diving_cave == null
           ? null
-          : parseInt(avgDepthAndLength.avg_length, 10),
-    },
-    total_length: {
-      value:
-        totalLength.value === null ? null : parseInt(totalLength.value, 10),
-      nb_data:
-        totalLength.nb_data === null
-          ? null
-          : Number.parseInt(totalLength.nb_data, 10),
-    },
-  };
-  return ControllerService.treat(
-    req,
-    null,
-    data,
-    { controllerMethod: 'MassifController.get-statistics' },
-    res
-  );
+          : parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
+      avg: {
+        avg_depth:
+          avgDepthAndLength?.avg_depth == null
+            ? null
+            : parseInt(avgDepthAndLength.avg_depth, 10),
+        avg_length:
+          avgDepthAndLength?.avg_length == null
+            ? null
+            : parseInt(avgDepthAndLength.avg_length, 10),
+      },
+      total_length: {
+        value:
+          totalLength?.value == null ? null : parseInt(totalLength.value, 10),
+        nb_data:
+          totalLength?.nb_data == null
+            ? null
+            : Number.parseInt(totalLength.nb_data, 10),
+      },
+    };
+
+    return ControllerService.treat(
+      req,
+      null,
+      data,
+      { controllerMethod: 'MassifController.get-statistics' },
+      res
+    );
+  } catch (err) {
+    return ControllerService.treat(
+      req,
+      err,
+      null,
+      { controllerMethod: 'MassifController.get-statistics' },
+      res
+    );
+  }
 };

--- a/api/controllers/v1/region/get-statistics.js
+++ b/api/controllers/v1/region/get-statistics.js
@@ -7,79 +7,89 @@ module.exports = async (req, res) => {
 
   // Check if ISO 3166-2 region exists
   const isoCode = `${countryId}-${regionId}`;
-  const region = await TISO31662.findOne({ id: isoCode });
-  if (!region) {
-    return res.notFound({
-      message: `Region ${isoCode} not found.`,
-    });
+
+  try {
+    const region = await TISO31662.findOne({ id: isoCode });
+    if (!region) {
+      return res.notFound({
+        message: `Region ${isoCode} not found.`,
+      });
+    }
+
+    const [
+      nbMassifs,
+      nbCaves,
+      nbNetworks,
+      caveWithMaxDepth,
+      caveWithMaxLength,
+      nbCavesWhichAreDiving,
+      avgDepthAndLength,
+      totalLength,
+    ] = await Promise.all([
+      StatisticsRegionService.getNbMassifsInRegion(isoCode),
+      StatisticsRegionService.getNbCavesInRegion(isoCode),
+      StatisticsRegionService.getNbNetworksInRegion(isoCode),
+      StatisticsRegionService.getCaveWithMaxDepthInRegion(isoCode),
+      StatisticsRegionService.getCaveWithMaxLengthInRegion(isoCode),
+      StatisticsRegionService.getNbCavesWhichAreDivingInRegion(isoCode),
+      StatisticsRegionService.getAvgDepthAndLengthInRegion(isoCode),
+      StatisticsRegionService.getTotalLength(isoCode),
+    ]);
+
+    // to avoid that the function parseInt returns NaN when the value is null, we test the value before
+    // if the value is null, we return null
+    const data = {
+      nb_massifs:
+        nbMassifs?.nb_massifs == null
+          ? null
+          : Number.parseInt(nbMassifs.nb_massifs, 10),
+      nb_caves:
+        nbCaves?.nb_caves == null
+          ? null
+          : Number.parseInt(nbCaves.nb_caves, 10),
+      nb_networks:
+        nbNetworks?.nb_networks == null
+          ? null
+          : Number.parseInt(nbNetworks.nb_networks, 10),
+      cave_with_max_depth: caveWithMaxDepth,
+      cave_with_max_length: caveWithMaxLength,
+      diving_caves:
+        nbCavesWhichAreDiving?.nb_diving_cave == null
+          ? null
+          : Number.parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
+      avg: {
+        avg_depth:
+          avgDepthAndLength?.avg_depth == null
+            ? null
+            : Number.parseInt(avgDepthAndLength.avg_depth, 10),
+        avg_length:
+          avgDepthAndLength?.avg_length == null
+            ? null
+            : Number.parseInt(avgDepthAndLength.avg_length, 10),
+      },
+      total_length: {
+        value:
+          totalLength?.value == null
+            ? null
+            : Number.parseInt(totalLength.value, 10),
+        nb_data:
+          totalLength?.nb_data == null
+            ? null
+            : Number.parseInt(totalLength.nb_data, 10),
+      },
+    };
+
+    return ControllerService.treat(
+      req,
+      null,
+      data,
+      { controllerMethod: 'RegionController.get-statistics' },
+      res
+    );
+  } catch (err) {
+    sails.log.error(err);
+    return res.serverError(
+      'An internal error occurred when getting region statistics'
+    );
   }
-
-  const [
-    nbMassifs,
-    nbCaves,
-    nbNetworks,
-    caveWithMaxDepth,
-    caveWithMaxLength,
-    nbCavesWhichAreDiving,
-    avgDepthAndLength,
-    totalLength,
-  ] = await Promise.all([
-    StatisticsRegionService.getNbMassifsInRegion(isoCode),
-    StatisticsRegionService.getNbCavesInRegion(isoCode),
-    StatisticsRegionService.getNbNetworksInRegion(isoCode),
-    StatisticsRegionService.getCaveWithMaxDepthInRegion(isoCode),
-    StatisticsRegionService.getCaveWithMaxLengthInRegion(isoCode),
-    StatisticsRegionService.getNbCavesWhichAreDivingInRegion(isoCode),
-    StatisticsRegionService.getAvgDepthAndLengthInRegion(isoCode),
-    StatisticsRegionService.getTotalLength(isoCode),
-  ]);
-
-  const data = {
-    nb_massifs:
-      nbMassifs && nbMassifs.nb_massifs === null
-        ? null
-        : Number.parseInt(nbMassifs.nb_massifs, 10),
-    nb_caves:
-      nbCaves && nbCaves.nb_caves === null
-        ? null
-        : Number.parseInt(nbCaves.nb_caves, 10),
-    nb_networks:
-      nbNetworks && nbNetworks.nb_networks === null
-        ? null
-        : Number.parseInt(nbNetworks.nb_networks, 10),
-    cave_with_max_depth: caveWithMaxDepth,
-    cave_with_max_length: caveWithMaxLength,
-    diving_caves:
-      nbCavesWhichAreDiving && nbCavesWhichAreDiving.nb_diving_cave === null
-        ? null
-        : Number.parseInt(nbCavesWhichAreDiving.nb_diving_cave, 10),
-    avg: {
-      avg_depth:
-        avgDepthAndLength && avgDepthAndLength.avg_depth === null
-          ? null
-          : Number.parseInt(avgDepthAndLength.avg_depth, 10),
-      avg_length:
-        avgDepthAndLength && avgDepthAndLength.avg_length === null
-          ? null
-          : Number.parseInt(avgDepthAndLength.avg_length, 10),
-    },
-    total_length: {
-      value:
-        totalLength && totalLength.value === null
-          ? null
-          : Number.parseInt(totalLength.value, 10),
-      nb_data:
-        totalLength && totalLength.nb_data === null
-          ? null
-          : Number.parseInt(totalLength.nb_data, 10),
-    },
-  };
-
-  return ControllerService.treat(
-    req,
-    null,
-    data,
-    { controllerMethod: 'RegionController.get-statistics' },
-    res
-  );
 };

--- a/api/services/MassifService.js
+++ b/api/services/MassifService.js
@@ -142,12 +142,14 @@ const COUNT_LOCKED_UNSENSITIVE_ENTRANCES_IN_MASSIF = `
   AND e.is_sensitive_locked = true
 `;
 
-async function safeDBQuery(sql, param) {
+// Spatial queries using ST_Contains can throw when point_geom is null rather than
+// returning an empty result set. This wrapper normalises that to an empty array.
+async function querySpatialRows(sql, param) {
   try {
     const queryResult = await CommonService.query(sql, [param]);
     return queryResult.rows;
   } catch (e) {
-    return []; // Fail silently (happens when the longitude and latitude are null for example)
+    return [];
   }
 }
 
@@ -276,7 +278,8 @@ module.exports = {
     await SearchService.updateDocument('massifs', massif);
   },
 
-  getCaves: async (massifId) => safeDBQuery(FIND_CAVES_IN_MASSIF, massifId),
+  getCaves: async (massifId) =>
+    querySpatialRows(FIND_CAVES_IN_MASSIF, massifId),
   countEntrances: async (massifId) => {
     try {
       const result = await CommonService.query(COUNT_ENTRANCES_IN_MASSIF, [
@@ -319,7 +322,7 @@ module.exports = {
     }
   },
   getNetworks: async (massifId) =>
-    safeDBQuery(FIND_NETWORKS_IN_MASSIF, massifId),
+    querySpatialRows(FIND_NETWORKS_IN_MASSIF, massifId),
 
   geoJsonToWKT: async (geoJson) => {
     const query = `SELECT ST_AsText($1) `;

--- a/api/services/StatisticsCountryService.js
+++ b/api/services/StatisticsCountryService.js
@@ -1,10 +1,3 @@
-const FIND_COUNTRY_IN_VIEW = `
-  SELECT id_country
-  FROM v_country_info
-  WHERE id_country = $1
-  LIMIT 1
-`;
-
 const GET_NB_MASSIFS = `
   SELECT COUNT(*) as nb_massifs
   FROM (
@@ -76,99 +69,79 @@ const GET_TOTAL_LENGTH_IN_COUNTRY = `
 
 const CommonService = require('./CommonService');
 
-async function safeDBQuery(sql, param) {
-  try {
-    const queryResult = await CommonService.query(sql, [param]);
-    const result = queryResult.rows;
-    if (result.length > 0) {
-      return result[0];
-    }
-    return null;
-  } catch (e) {
-    return null;
+async function queryFirstRow(sql, param) {
+  const queryResult = await CommonService.query(sql, [param]);
+  const result = queryResult.rows;
+  if (result.length > 0) {
+    return result[0];
   }
+  return null;
 }
 
 module.exports = {
   /**
    *
-   * @param {int} countryId
-   * @returns {boolean} true if there is some line about this country, else false
-   */
-  isCountryInView: async (countryId) => {
-    const result = await safeDBQuery(FIND_COUNTRY_IN_VIEW, countryId);
-    return result;
-  },
-
-  /**
-   *
    * @param {string} countryId
-   * @returns {int} the number of massifs in the country
-   *                or null if no result or something went wrong
+   * @returns {int} the number of massifs in the country, or null if no result
    */
   getNbMassifsInCountry: async (countryId) =>
-    safeDBQuery(GET_NB_MASSIFS, countryId),
+    queryFirstRow(GET_NB_MASSIFS, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {int} the number of caves in the country
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves in the country, or null if no result
    */
   getNbCavesInCountry: async (countryId) =>
-    safeDBQuery(GET_NB_CAVES, countryId),
+    queryFirstRow(GET_NB_CAVES, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {int} the number of networks in the country
-   *                or null if no result or something went wrong
+   * @returns {int} the number of networks in the country, or null if no result
    */
   getNbNetworksInCountry: async (countryId) =>
-    safeDBQuery(GET_NB_NETWORKS, countryId),
+    queryFirstRow(GET_NB_NETWORKS, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {Object} the cave with the maximum depth in the country (id, name and depth)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum depth in the country (id, name and depth),
+   *                   or null if no result
    */
   getCaveWithMaxDepthInCountry: async (countryId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_DEPTH_IN_COUNTRY, countryId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_DEPTH_IN_COUNTRY, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {Object} the cave with the maximum length in the country (id, name and length)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum length in the country (id, name and length),
+   *                   or null if no result
    */
   getCaveWithMaxLengthInCountry: async (countryId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_LENGTH_IN_COUNTRY, countryId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_LENGTH_IN_COUNTRY, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {int} the number of caves which are diving in the country
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves which are diving in the country, or null if no result
    */
   getNbCavesWhichAreDivingInCountry: async (countryId) =>
-    safeDBQuery(GET_NB_CAVES_WHICH_ARE_DIVING_IN_COUNTRY, countryId),
+    queryFirstRow(GET_NB_CAVES_WHICH_ARE_DIVING_IN_COUNTRY, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {Object} the average depth and length in the country
-   *                or null if no result or something went wrong
+   * @returns {Object} the average depth and length in the country, or null if no result
    */
   getAvgDepthAndLengthInCountry: async (countryId) =>
-    safeDBQuery(GET_AVG_DEPTH_AND_LENGTH_IN_COUNTRY, countryId),
+    queryFirstRow(GET_AVG_DEPTH_AND_LENGTH_IN_COUNTRY, countryId),
 
   /**
    *
    * @param {string} countryId
-   * @returns {int} the sum of the lengths of each cave in the country
-   *                or null if no result or something went wrong
+   * @returns {int} the sum of the lengths of each cave in the country, or null if no result
    */
   getTotalLength: async (countryId) =>
-    safeDBQuery(GET_TOTAL_LENGTH_IN_COUNTRY, countryId),
+    queryFirstRow(GET_TOTAL_LENGTH_IN_COUNTRY, countryId),
 };

--- a/api/services/StatisticsMassifService.js
+++ b/api/services/StatisticsMassifService.js
@@ -51,7 +51,7 @@ const GET_TOTAL_LENGTH_IN_MASSIF = `
 
 const CommonService = require('./CommonService');
 
-async function safeDBQuery(sql, param) {
+async function queryFirstRow(sql, param) {
   const queryResult = await CommonService.query(sql, [param]);
   const result = queryResult.rows;
   if (result.length > 0) {
@@ -64,62 +64,57 @@ module.exports = {
   /**
    *
    * @param {int} massifId
-   * @returns {int} the number of caves in the massif
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves in the massif, or null if no result
    */
-  getNbCavesInMassif: async (massifId) => safeDBQuery(GET_NB_CAVES, massifId),
+  getNbCavesInMassif: async (massifId) => queryFirstRow(GET_NB_CAVES, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {int} the number of networks in the massif
-   *                or null if no result or something went wrong
+   * @returns {int} the number of networks in the massif, or null if no result
    */
   getNbNetworksInMassif: async (massifId) =>
-    safeDBQuery(GET_NB_NETWORKS, massifId),
+    queryFirstRow(GET_NB_NETWORKS, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {Object} the cave with the maximum depth in the massif (id, name and depth)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum depth in the massif (id, name and depth),
+   *                   or null if no result
    */
   getCaveWithMaxDepthInMassif: async (massifId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_DEPTH_IN_MASSIF, massifId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_DEPTH_IN_MASSIF, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {Object} the cave with the maximum length in the massif (id, name and length)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum length in the massif (id, name and length),
+   *                   or null if no result
    */
   getCaveWithMaxLengthInMassif: async (massifId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_LENGTH_IN_MASSIF, massifId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_LENGTH_IN_MASSIF, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {int} the number of caves which are diving in the massif
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves which are diving in the massif, or null if no result
    */
   getNbCavesWhichAreDivingInMassif: async (massifId) =>
-    safeDBQuery(GET_NB_CAVES_WHICH_ARE_DIVING_IN_MASSIF, massifId),
+    queryFirstRow(GET_NB_CAVES_WHICH_ARE_DIVING_IN_MASSIF, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {Object} the average depth and length in the massif
-   *                or null if no result or something went wrong
+   * @returns {Object} the average depth and length in the massif, or null if no result
    */
   getAvgDepthAndLengthInMassif: async (massifId) =>
-    safeDBQuery(GET_AVG_DEPTH_AND_LENGTH_IN_MASSIF, massifId),
+    queryFirstRow(GET_AVG_DEPTH_AND_LENGTH_IN_MASSIF, massifId),
 
   /**
    *
    * @param {int} massifId
-   * @returns {int} the sum of the lengths of each cave in the massif
-   *                or null if no result or something went wrong
+   * @returns {int} the sum of the lengths of each cave in the massif, or null if no result
    */
   getTotalLength: async (massifId) =>
-    safeDBQuery(GET_TOTAL_LENGTH_IN_MASSIF, massifId),
+    queryFirstRow(GET_TOTAL_LENGTH_IN_MASSIF, massifId),
 };

--- a/api/services/StatisticsMassifService.js
+++ b/api/services/StatisticsMassifService.js
@@ -1,10 +1,3 @@
-const FIND_MASSIF_IN_VIEW = `
-  SELECT id_massif
-  FROM v_massif_info
-  WHERE id_massif = $1
-  LIMIT 1
-`;
-
 const GET_NB_CAVES = `
   SELECT COUNT(*) as nb_caves
   FROM v_massif_info
@@ -59,29 +52,15 @@ const GET_TOTAL_LENGTH_IN_MASSIF = `
 const CommonService = require('./CommonService');
 
 async function safeDBQuery(sql, param) {
-  try {
-    const queryResult = await CommonService.query(sql, [param]);
-    const result = queryResult.rows;
-    if (result.length > 0) {
-      return result[0];
-    }
-    return null;
-  } catch (e) {
-    return null;
+  const queryResult = await CommonService.query(sql, [param]);
+  const result = queryResult.rows;
+  if (result.length > 0) {
+    return result[0];
   }
+  return null;
 }
 
 module.exports = {
-  /**
-   *
-   * @param {int} massifId
-   * @returns {boolean} true if there is some line about this massif, else false
-   */
-  isMassifInView: async (massifId) => {
-    const result = await safeDBQuery(FIND_MASSIF_IN_VIEW, massifId);
-    return result;
-  },
-
   /**
    *
    * @param {int} massifId

--- a/api/services/StatisticsRegionService.js
+++ b/api/services/StatisticsRegionService.js
@@ -1,10 +1,3 @@
-const FIND_REGION_IN_VIEW = `
-  SELECT id_region
-  FROM v_region_info
-  WHERE id_region = $1
-  LIMIT 1
-`;
-
 const GET_NB_MASSIFS = `
   SELECT COUNT(*) as nb_massifs
   FROM (
@@ -76,98 +69,78 @@ const GET_TOTAL_LENGTH_IN_REGION = `
 
 const CommonService = require('./CommonService');
 
-async function safeDBQuery(sql, param) {
-  try {
-    const queryResult = await CommonService.query(sql, [param]);
-    const result = queryResult.rows;
-    if (result.length > 0) {
-      return result[0];
-    }
-    return null;
-  } catch (e) {
-    return null;
+async function queryFirstRow(sql, param) {
+  const queryResult = await CommonService.query(sql, [param]);
+  const result = queryResult.rows;
+  if (result.length > 0) {
+    return result[0];
   }
+  return null;
 }
 
 module.exports = {
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {boolean} true if there is some line about this region, else false
-   */
-  isRegionInView: async (regionId) => {
-    const result = await safeDBQuery(FIND_REGION_IN_VIEW, regionId);
-    return result;
-  },
-
-  /**
-   *
-   * @param {string} regionId ISO 3166-2 code
-   * @returns {int} the number of massifs in the region
-   *                or null if no result or something went wrong
+   * @returns {int} the number of massifs in the region, or null if no result
    */
   getNbMassifsInRegion: async (regionId) =>
-    safeDBQuery(GET_NB_MASSIFS, regionId),
+    queryFirstRow(GET_NB_MASSIFS, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {int} the number of caves in the region
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves in the region, or null if no result
    */
-  getNbCavesInRegion: async (regionId) => safeDBQuery(GET_NB_CAVES, regionId),
+  getNbCavesInRegion: async (regionId) => queryFirstRow(GET_NB_CAVES, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {int} the number of networks in the region
-   *                or null if no result or something went wrong
+   * @returns {int} the number of networks in the region, or null if no result
    */
   getNbNetworksInRegion: async (regionId) =>
-    safeDBQuery(GET_NB_NETWORKS, regionId),
+    queryFirstRow(GET_NB_NETWORKS, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {Object} the cave with the maximum depth in the region (id, name and depth)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum depth in the region (id, name and depth),
+   *                   or null if no result
    */
   getCaveWithMaxDepthInRegion: async (regionId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_DEPTH_IN_REGION, regionId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_DEPTH_IN_REGION, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {Object} the cave with the maximum length in the region (id, name and length)
-   *                or null if no result or something went wrong
+   * @returns {Object} the cave with the maximum length in the region (id, name and length),
+   *                   or null if no result
    */
   getCaveWithMaxLengthInRegion: async (regionId) =>
-    safeDBQuery(FIND_CAVE_WITH_MAX_LENGTH_IN_REGION, regionId),
+    queryFirstRow(FIND_CAVE_WITH_MAX_LENGTH_IN_REGION, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {int} the number of caves which are diving in the region
-   *                or null if no result or something went wrong
+   * @returns {int} the number of caves which are diving in the region, or null if no result
    */
   getNbCavesWhichAreDivingInRegion: async (regionId) =>
-    safeDBQuery(GET_NB_CAVES_WHICH_ARE_DIVING_IN_REGION, regionId),
+    queryFirstRow(GET_NB_CAVES_WHICH_ARE_DIVING_IN_REGION, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {Object} the average depth and length in the region
-   *                or null if no result or something went wrong
+   * @returns {Object} the average depth and length in the region, or null if no result
    */
   getAvgDepthAndLengthInRegion: async (regionId) =>
-    safeDBQuery(GET_AVG_DEPTH_AND_LENGTH_IN_REGION, regionId),
+    queryFirstRow(GET_AVG_DEPTH_AND_LENGTH_IN_REGION, regionId),
 
   /**
    *
    * @param {string} regionId ISO 3166-2 code
-   * @returns {int} the sum of the lengths of each cave in the region
-   *                or null if no result or something went wrong
+   * @returns {int} the sum of the lengths of each cave in the region, or null if no result
    */
   getTotalLength: async (regionId) =>
-    safeDBQuery(GET_TOTAL_LENGTH_IN_REGION, regionId),
+    queryFirstRow(GET_TOTAL_LENGTH_IN_REGION, regionId),
 };

--- a/sql/1_cron.sql
+++ b/sql/1_cron.sql
@@ -11,12 +11,29 @@ SELECT cron.schedule_in_database(
 );
 
 
+-- Three separate jobs so that a failure in one view never rolls back or blocks the others.
 SELECT cron.schedule_in_database(
-    'Refresh info views every 3 days', -- every 3 days at 4h40
-    '40 4 */3 * *',
+    'Refresh massif info view every 3 days',
+    '40 4 */3 * *', -- every 3 days at 4h40
     $$
         REFRESH MATERIALIZED VIEW CONCURRENTLY v_massif_info;
+    $$,
+    'grottoce'
+);
+
+SELECT cron.schedule_in_database(
+    'Refresh country info view every 3 days',
+    '45 4 */3 * *', -- every 3 days at 4h45 (staggered 5 min after massif)
+    $$
         REFRESH MATERIALIZED VIEW CONCURRENTLY v_country_info;
+    $$,
+    'grottoce'
+);
+
+SELECT cron.schedule_in_database(
+    'Refresh region info view every 3 days',
+    '50 4 */3 * *', -- every 3 days at 4h50 (staggered 10 min after massif)
+    $$
         REFRESH MATERIALIZED VIEW CONCURRENTLY v_region_info;
     $$,
     'grottoce'
@@ -24,4 +41,4 @@ SELECT cron.schedule_in_database(
 
 
 -- To view all jobs: select * from cron.job;
--- To remove a job: SELECT cron.unschedule('Refresh data quality view daily');
+-- To remove a job: SELECT cron.unschedule('Refresh massif info view every 3 days');

--- a/sql/91_materialized_views.sql
+++ b/sql/91_materialized_views.sql
@@ -318,5 +318,8 @@ SELECT
 CREATE UNIQUE INDEX ON v_data_quality_compute_entrance(id_massif, id_entrance);
 CREATE INDEX IF NOT EXISTS idx_vdqce_entrance_massif ON v_data_quality_compute_entrance (id_entrance, id_massif);
 CREATE UNIQUE INDEX ON v_massif_info(id_massif, id_cave);
-CREATE UNIQUE INDEX ON v_country_info(id_massif, id_cave);
+-- id_country is part of the GROUP BY key, so a cave that spans two countries inside the same massif
+-- produces two rows with distinct id_country but the same (id_massif, id_cave) pair.
+-- The index must include id_country to remain unique across all rows.
+CREATE UNIQUE INDEX ON v_country_info(id_country, id_massif, id_cave);
 CREATE UNIQUE INDEX ON v_region_info(id_massif, id_cave, id_region);

--- a/test/fixtures/tmassif.json
+++ b/test/fixtures/tmassif.json
@@ -28,5 +28,11 @@
     "isSensitive": false,
     "geogPolygon": "POLYGON((1.9 1.9, 1.9 2.1, 2.1 2.1, 2.1 1.9, 1.9 1.9))",
     "names": [101]
+  },
+  {
+    "id": 102,
+    "author": 2,
+    "isDeleted": true,
+    "names": [102]
   }
 ]

--- a/test/fixtures/tname.json
+++ b/test/fixtures/tname.json
@@ -130,5 +130,15 @@
     "name": "Unsensitive Massif 101",
     "isMain": true,
     "language": "eng"
+  },
+  {
+    "id": 102,
+    "author": 1,
+    "reviewer": 2,
+    "dateInscription": "2024-01-01 00:00:00",
+    "dateReviewed": "2024-01-02 00:00:00",
+    "name": "Deleted Massif 102",
+    "isMain": true,
+    "language": "eng"
   }
 ]

--- a/test/integration/1_services/StatisticsCountryService.test.js
+++ b/test/integration/1_services/StatisticsCountryService.test.js
@@ -2,19 +2,6 @@ const should = require('should');
 const StatisticsCountryService = require('../../../api/services/StatisticsCountryService');
 
 describe('StatisticsCountryService', () => {
-  describe('isCountryInView()', () => {
-    it('should return country data when country exists', async () => {
-      const result = await StatisticsCountryService.isCountryInView('FR');
-      should.exist(result);
-      result.should.have.property('id_country', 'FR');
-    });
-
-    it('should return null when country does not exist', async () => {
-      const result = await StatisticsCountryService.isCountryInView('XX');
-      should(result).be.null();
-    });
-  });
-
   describe('getNbMassifsInCountry()', () => {
     it('should count distinct massifs (3 massifs)', async () => {
       const result = await StatisticsCountryService.getNbMassifsInCountry('FR');

--- a/test/integration/1_services/StatisticsMassifService.test.js
+++ b/test/integration/1_services/StatisticsMassifService.test.js
@@ -2,19 +2,6 @@ const should = require('should');
 const StatisticsMassifService = require('../../../api/services/StatisticsMassifService');
 
 describe('StatisticsMassifService', () => {
-  describe('isMassifInView()', () => {
-    it('should return massif data when massif exists', async () => {
-      const result = await StatisticsMassifService.isMassifInView(1);
-      should.exist(result);
-      result.should.have.property('id_massif', 1);
-    });
-
-    it('should return null when massif does not exist', async () => {
-      const result = await StatisticsMassifService.isMassifInView(999);
-      should(result).be.null();
-    });
-  });
-
   describe('getNbCavesInMassif()', () => {
     it('should count caves in massif 1 (2 caves)', async () => {
       const result = await StatisticsMassifService.getNbCavesInMassif(1);

--- a/test/integration/1_services/StatisticsRegionService.test.js
+++ b/test/integration/1_services/StatisticsRegionService.test.js
@@ -2,19 +2,6 @@ const should = require('should');
 const StatisticsRegionService = require('../../../api/services/StatisticsRegionService');
 
 describe('StatisticsRegionService', () => {
-  describe('isRegionInView()', () => {
-    it('should return region data when region exists', async () => {
-      const result = await StatisticsRegionService.isRegionInView('FR-ARA');
-      should.exist(result);
-      result.should.have.property('id_region', 'FR-ARA');
-    });
-
-    it('should return null when region does not exist', async () => {
-      const result = await StatisticsRegionService.isRegionInView('XX-XXX');
-      should(result).be.null();
-    });
-  });
-
   describe('getNbMassifsInRegion()', () => {
     it('should count distinct massifs (2 massifs in FR-ARA)', async () => {
       const result =

--- a/test/integration/4_routes/Countries/get-statistics.test.js
+++ b/test/integration/4_routes/Countries/get-statistics.test.js
@@ -25,5 +25,17 @@ describe('Country statistics features', () => {
         .set('Accept', 'application/json')
         .expect(200);
     });
+
+    it('should return 200 with zero stats for a country absent from the materialized view', async () => {
+      // GB exists in t_country but has no rows in v_country_info.
+      // Before this fix, the view-based existence check caused a 404.
+      const response = await supertest(sails.hooks.http.app)
+        .get('/api/v1/countries/GB/statistics')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      response.body.nb_caves.should.equal(0);
+    });
   });
 });

--- a/test/integration/4_routes/Massifs/get-statistics.test.js
+++ b/test/integration/4_routes/Massifs/get-statistics.test.js
@@ -18,6 +18,38 @@ describe('Massif statistics features', () => {
         .expect(404);
     });
 
+    it('should return 404 for a non-numeric massif id', async () => {
+      // Number('abc') === NaN — Waterline would throw E_INVALID_PK_VALUE (500).
+      // The guard must intercept this before the DB lookup.
+      await supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/abc/statistics')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404);
+    });
+
+    it('should return 404 for a soft-deleted massif', async () => {
+      // Massif 102 exists in t_massif but has is_deleted = true.
+      // The controller must check the real table, not the view.
+      await supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/102/statistics')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(404);
+    });
+
+    it('should return 200 with zero stats for a massif absent from the materialized view', async () => {
+      // Massif 101 exists in t_massif but has no rows in v_massif_info.
+      // Before this fix, the view-based existence check caused a 404.
+      const response = await supertest(sails.hooks.http.app)
+        .get('/api/v1/massifs/101/statistics')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      response.body.nb_caves.should.equal(0);
+    });
+
     it('should return statistics for valid massif', async () => {
       await supertest(sails.hooks.http.app)
         .get('/api/v1/massifs/1/statistics')


### PR DESCRIPTION
## 🤔 What

Fix stale materialized views causing `GET /api/v1/massifs/:id/statistics` to return 404 for massifs that exist and have caves. Addresses items 1–3 from #1754 (item 4 — cron failure alerting — is tracked separately).

- Split the single shared cron job body into three independent `pg_cron` jobs
- Fix the `v_country_info` unique index to include `id_country`
- Replace the `isMassifInView()` existence check with a direct `TMassif` table lookup

## 🤷‍♂️ Why

Since 2026-07-01, every refresh of the three "info" materialized views has failed silently. The root causes were chained:

1. **Shared cron job** — `v_massif_info`, `v_country_info`, and `v_region_info` were all refreshed in a single `pg_cron` job body. Because `pg_cron` executes multi-statement strings as one implicit transaction, a failure on statement 2 rolled back the successful statement 1. `v_massif_info` was never updated despite succeeding.

2. **Wrong unique index on `v_country_info`** — the index was on `(id_massif, id_cave)`, but the view's `GROUP BY` includes `id_country`. Cave 75266 (Pierre-Saint-Martin) has entrances in both FR and ES inside massif 4, producing two rows with the same `(id_massif, id_cave)` pair. `REFRESH MATERIALIZED VIEW CONCURRENTLY` aborted every time.

3. **View-based existence check** — `isMassifInView()` checked the materialized view to decide whether to 404. A stale or empty view made every massif that wasn't cached appear non-existent.

## 🔍 How

- **`sql/1_cron.sql`**: Replaced the single multi-statement job with four independent `cron.schedule_in_database` calls — one per view, staggered by 5 minutes. A failure in one view no longer affects the others.
- **`sql/91_materialized_views.sql`**: Changed `CREATE UNIQUE INDEX ON v_country_info(id_massif, id_cave)` to `(id_country, id_massif, id_cave)`, matching the actual `GROUP BY` key.
- **`api/services/StatisticsMassifService.js`**: Removed `isMassifInView()` and the silent `try/catch` in `safeDBQuery` that discarded errors. Errors now propagate to the caller.
- **`api/controllers/v1/massif/get-statistics.js`**: Replaced the view check with `TMassif.findOne({ id, isDeleted: false })`, wrapped everything in a `try/catch` that routes to `ControllerService.treat`.

## 🧪 Testing

- Existing `StatisticsMassifService` tests updated to remove `isMassifInView()` coverage (method deleted); all other service tests pass.
- The SQL migration changes require `npm run dev:clean` to take effect locally.
- In production, the three fixes were applied manually on 2026-08-05; this PR captures them in the codebase.

## 📸 Previews

N/A — JSON API endpoint, no UI changes.
