### PR TITLE
fix(massif): set reviewer on update to fix recent-changes feed

### DIFF
--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -12,7 +12,10 @@ module.exports = async (req, res) => {
     return res.notFound({ message: `Massif of id ${massifId} not found.` });
   }
 
-  const cleanedData = MassifService.getConvertedDataFromClientRequest(req);
+  const cleanedData = {
+    reviewer: req.token.id,
+    ...MassifService.getConvertedDataFromClientRequest(req),
+  };
 
   // conversion of geoJson into PostGis Geom
   if (cleanedData.geogPolygon) {

--- a/api/controllers/v1/massif/update.js
+++ b/api/controllers/v1/massif/update.js
@@ -13,8 +13,9 @@ module.exports = async (req, res) => {
   }
 
   const cleanedData = {
-    reviewer: req.token.id,
+    // dateReviewed will be updated automatically by the SQL historisation trigger
     ...MassifService.getConvertedDataFromClientRequest(req),
+    reviewer: req.token.id,
   };
 
   // conversion of geoJson into PostGis Geom
@@ -63,21 +64,19 @@ module.exports = async (req, res) => {
 
   // Handle name update inline (consistent with entrance and cave update)
   if (req.body.name) {
-    const nameUpdate = {};
+    const nameUpdate = { reviewer: req.token.id };
     if (nameText !== undefined) {
       nameUpdate.name = nameText;
     }
     if (nameLanguage !== undefined) {
       nameUpdate.language = nameLanguage;
     }
-    if (Object.keys(nameUpdate).length > 0) {
-      const updatedName = await TName.updateOne({
-        massif: massifId,
-        isMain: true,
-      }).set(nameUpdate);
-      if (!updatedName) {
-        sails.log.warn(`Massif ${massifId} has no main name record to update.`);
-      }
+    const updatedName = await TName.updateOne({
+      massif: massifId,
+      isMain: true,
+    }).set(nameUpdate);
+    if (!updatedName) {
+      sails.log.warn(`Massif ${massifId} has no main name record to update.`);
     }
   }
 

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -118,6 +118,56 @@ describe('Massif features', () => {
         });
     });
 
+    it('should appear as update (not create) in the recent-changes feed after a second PUT (#1769)', async () => {
+      // Regression: before the fix, reviewer was never set so id_reviewer stayed NULL,
+      // and the change_massif trigger always classified edits as 'create'.
+      //
+      // This test creates a massif with reviewer=null (simulating a freshly created
+      // entity that has never been edited), issues two consecutive PUTs, and asserts
+      // that reviewer is set after the first PUT and remains set after the second.
+      // The change_massif DB trigger uses id_reviewer IS NULL to decide 'create' vs
+      // 'update' — so a populated reviewer is both necessary and sufficient for
+      // subsequent edits to be classified as 'update' in the feed.
+      const stub = sinon.stub(EntranceService, 'updateInSearch').resolves();
+      let nullReviewerMassifId;
+      try {
+        // Create a massif with no reviewer (as the create controller leaves it)
+        const freshMassif = await TMassif.create({ author: 1 }).fetch();
+        nullReviewerMassifId = freshMassif.id;
+        should(freshMassif.reviewer).be.null();
+
+        // First PUT — reviewer was null; after this call the controller must set it
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/massifs/${nullReviewerMassifId}`)
+          .send({ descriptions: [testDescId] })
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+
+        const afterFirst = await TMassif.findOne(nullReviewerMassifId);
+        should(afterFirst.reviewer).not.be.null();
+
+        // Second PUT — reviewer is now populated; must stay set so the trigger
+        // keeps classifying this as 'update' rather than reverting to 'create'
+        await supertest(sails.hooks.http.app)
+          .put(`/api/v1/massifs/${nullReviewerMassifId}`)
+          .send({ descriptions: [testDescId] })
+          .set('Authorization', userToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+
+        const afterSecond = await TMassif.findOne(nullReviewerMassifId);
+        should(afterSecond.reviewer).not.be.null();
+      } finally {
+        stub.restore();
+        if (nullReviewerMassifId) {
+          await TMassif.destroy({ id: nullReviewerMassifId });
+        }
+      }
+    });
+
     it('should return 400 when polygon area exceeds 35000 km²', (done) => {
       supertest(sails.hooks.http.app)
         .put(`/api/v1/massifs/${testMassifId}`)

--- a/test/integration/4_routes/Massifs/update.test.js
+++ b/test/integration/4_routes/Massifs/update.test.js
@@ -108,6 +108,12 @@ describe('Massif features', () => {
           ]);
           should(massifUpdated.geogPolygon).not.be.null();
           should(massifUpdated.names).containDeep([{ id: testNameId }]);
+
+          // reviewer must be set so the DB trigger classifies subsequent edits as 'update'
+          // not 'create' in the recent changes feed (issue #1769)
+          const userCaver = await TCaver.findOne({ mail: 'user1@user1.com' });
+          should(massifUpdated.reviewer).equal(userCaver.id);
+
           return done();
         });
     });


### PR DESCRIPTION
Fixes massif edits always appearing as "created" in the recent-changes feed.

## Why

The `change_massif` DB trigger uses `id_reviewer IS NULL` to decide whether a row has ever been edited:

```sql
elsif NEW.is_deleted = false AND NEW.id_reviewer is null then
    type_change := 'create';
elsif NEW.is_deleted = false then
    type_change := 'update';
```

`massif/update.js` never set `reviewer`, so `id_reviewer` stayed `NULL` permanently. Every edit — first or hundredth — was classified as `create` in the feed. All other entity update controllers (cave, entrance, organization, rigging, etc.) already set `reviewer: req.token.id`.

## What

- Add `reviewer: req.token.id` to the update payload in `api/controllers/v1/massif/update.js`
- Add a reviewer assertion to the existing update integration test

## Related

- Closes #1769
