### PR TITLE
fix(recentChanges): relevance swap corrupts recent changes feed

### DIFF
--- a/api/models/TLastChange.js
+++ b/api/models/TLastChange.js
@@ -32,9 +32,9 @@ module.exports = {
     },
 
     entityRelatedType: {
-      type: 'number',
+      type: 'string',
       columnName: 'type_related_entity',
-      columnType: 'int4',
+      columnType: 'varchar(30)',
     },
 
     entityRelatedId: {

--- a/api/services/RecentChangeService.js
+++ b/api/services/RecentChangeService.js
@@ -63,6 +63,10 @@ function groupChanges(changes) {
     mainAction: c.id_related_entity ? null : c.type_change, // Null in case it is a change on a sub entity
     subEntityTypes: c.id_related_entity ? [c.type_entity] : [],
     subAction: c.id_related_entity ? c.type_change : null, // Null when no sub entities
+    // Tracks the entity id that last set subAction, so we can apply
+    // create/restore priority correctly when the same entity is later
+    // seen with a higher-priority action (e.g. create after update).
+    subActionEntityId: c.id_related_entity ? c.id_entity : null,
     name: c.name, // Can be the real entity name or the related entity name
   });
 
@@ -75,8 +79,23 @@ function groupChanges(changes) {
       g.mainAction = c.type_change; // eslint-disable-line no-param-reassign
     if (c.id_related_entity && !g.subEntityTypes.includes(c.type_entity))
       g.subEntityTypes.push(c.type_entity);
-    if (c.id_related_entity && g.subAction !== c.type_change)
-      g.subAction = 'change'; // eslint-disable-line no-param-reassign
+    if (c.id_related_entity && g.subAction !== c.type_change) {
+      // 'create' and 'restore' take priority over 'update' only when it is the
+      // same entity that produced both events (e.g. a sub-entity was created
+      // then edited within the grouping window).  When different entity ids are
+      // involved the author genuinely performed mixed actions → 'change'.
+      if (
+        g.subAction === 'update' &&
+        ['create', 'restore'].includes(c.type_change) &&
+        g.subActionEntityId === c.id_entity
+      ) {
+        g.subAction = c.type_change; // eslint-disable-line no-param-reassign
+        g.subActionEntityId = c.id_entity; // eslint-disable-line no-param-reassign
+      } else {
+        g.subAction = 'change'; // eslint-disable-line no-param-reassign
+        g.subActionEntityId = null; // eslint-disable-line no-param-reassign
+      }
+    }
   };
 
   for (const change of changes) {
@@ -106,7 +125,9 @@ function groupChanges(changes) {
   }
 
   const allGroups = Object.values(authorChanges).flat();
-  return allGroups.sort((a, b) => b.date - a.date);
+  return allGroups
+    .sort((a, b) => b.date - a.date)
+    .map(({ subActionEntityId, ...group }) => group); // strip internal tracking field
 }
 
 async function getRecent() {

--- a/api/services/RecentChangeService.js
+++ b/api/services/RecentChangeService.js
@@ -90,7 +90,15 @@ function groupChanges(changes) {
         g.subActionEntityId === c.id_entity
       ) {
         g.subAction = c.type_change; // eslint-disable-line no-param-reassign
-        g.subActionEntityId = c.id_entity; // eslint-disable-line no-param-reassign
+        // subActionEntityId is already equal to c.id_entity (checked above).
+      } else if (
+        ['create', 'restore'].includes(g.subAction) &&
+        c.type_change === 'update' &&
+        g.subActionEntityId === c.id_entity
+      ) {
+        // 'create'/'restore' already wins — an incoming 'update' for the same
+        // entity must not downgrade it.  Leave subAction and subActionEntityId
+        // untouched.
       } else {
         g.subAction = 'change'; // eslint-disable-line no-param-reassign
         g.subActionEntityId = null; // eslint-disable-line no-param-reassign

--- a/api/services/RelevanceService.js
+++ b/api/services/RelevanceService.js
@@ -195,6 +195,12 @@ module.exports = {
           [],
           db
         );
+        // Model.tableName is safe to interpolate here: it is sourced from
+        // ENTITY_CONFIG, whose keys were validated by getConfig() earlier in
+        // this call stack.  Postgres does not support parameterized identifiers,
+        // so string interpolation is the correct and only option; the invariant
+        // that entityType was validated via getConfig() must be preserved if
+        // this code is ever refactored.
         await CommonService.query(
           `UPDATE ${Model.tableName} SET relevance = $1 WHERE id = $2`,
           [target.relevance, neighbor.id],

--- a/api/services/RelevanceService.js
+++ b/api/services/RelevanceService.js
@@ -4,6 +4,8 @@
  *
  * Models (TLocation, TDescription, etc.) are Sails globals - no imports needed.
  */
+const CommonService = require('./CommonService');
+
 const ENTITY_CONFIG = {
   location: {
     model: 'tlocation',
@@ -128,7 +130,7 @@ module.exports = {
     // Unranked entity: assign a position first, no swap needed.
     if (target.relevance == null) {
       sails.log.warn(
-        `moveRelevance: ${label} id=${entityId} has null relevance â€” assigning from computeNextRelevance`
+        `moveRelevance: ${label} id=${entityId} has null relevance — assigning from computeNextRelevance`
       );
       const nextRelevance = await this.computeNextRelevance(
         entityType,
@@ -175,12 +177,35 @@ module.exports = {
     const { moved, swapped } = await sails
       .getDatastore()
       .transaction(async (db) => {
+        // Update the target entity via Waterline so its change_* trigger fires
+        // and records this as an intentional move by the actor.
         const updatedTarget = await Model.updateOne({ id: entityId })
           .set({ relevance: neighbor.relevance })
           .usingConnection(db);
-        const updatedNeighbor = await Model.updateOne({ id: neighbor.id })
-          .set({ relevance: target.relevance })
-          .usingConnection(db);
+
+        // Update the neighbor's relevance using raw SQL with a session variable
+        // that tells the change_* trigger to skip logging.  The neighbor's
+        // relevance change is an involuntary side-effect of the move — no actor
+        // chose to update it, and logging it would attribute a spurious event
+        // to the original author.
+        // SET LOCAL scopes the variable to this transaction only; it reverts
+        // automatically when the transaction ends, so no explicit reset is needed.
+        await CommonService.query(
+          `SET LOCAL app.relevance_swap_skip_log TO 'true'`,
+          [],
+          db
+        );
+        await CommonService.query(
+          `UPDATE ${Model.tableName} SET relevance = $1 WHERE id = $2`,
+          [target.relevance, neighbor.id],
+          db
+        );
+
+        // Fetch via Waterline so `swapped` has the same shape (JS attribute
+        // names) as `moved`, which is also a Waterline record.
+        const updatedNeighbor = await Model.findOne({
+          id: neighbor.id,
+        }).usingConnection(db);
         return { moved: updatedTarget, swapped: updatedNeighbor };
       });
 

--- a/sql/1_2026_08_17_fix_change_triggers.sql
+++ b/sql/1_2026_08_17_fix_change_triggers.sql
@@ -1,0 +1,523 @@
+\c grottoce;
+
+-- =============================================================================
+-- Fix #1772: change_* triggers misclassify relevance swaps as 'create' events
+-- =============================================================================
+--
+-- Root cause: the original trigger logic used
+--   "NEW.is_deleted = false AND NEW.id_reviewer IS NULL"
+-- to detect a row creation.  This condition is true for ANY UPDATE where the
+-- reviewer has not yet been set — including pure relevance swaps — causing
+-- displaced sub-entities to be logged as newly created by their original author.
+--
+-- Fix 1: replace the condition with TG_OP = 'INSERT', which is unambiguously
+-- true only when the row is being inserted for the first time.  This mirrors
+-- the already-correct change_guideline() implementation.
+--
+-- Fix 2: add a session-variable guard at the top of each function so that
+-- RelevanceService can suppress the t_last_change entry for the involuntarily
+-- displaced neighbor (the entity whose relevance is swapped as a side-effect).
+-- The guard reads a transaction-scoped flag (SET LOCAL) that the application
+-- sets only for the neighbor update.  This pattern is already used by
+-- EnrichmentQueueService (app.is_enrichment).
+--
+-- Affected functions: change_grotto, change_massif, change_cave,
+--   change_entrance, change_document, change_history, change_location,
+--   change_comment, change_description, change_rigging.
+-- (change_guideline already uses TG_OP = 'INSERT' and is unchanged.)
+--
+-- Note: the relevance_swap_skip_log guard is applied only to the five
+-- sub-entity triggers (change_history, change_location, change_comment,
+-- change_description, change_rigging) that correspond to ENTITY_CONFIG in
+-- RelevanceService.  The top-level triggers (change_grotto, change_massif,
+-- change_cave, change_entrance, change_document) have no relevance column
+-- and are never touched by RelevanceService.moveRelevance, so no guard is
+-- needed there.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- change_grotto
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_grotto() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_grotto = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'grotto',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_massif
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_massif() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_massif = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'massif',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_cave
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_cave() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_cave = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'cave',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_entrance
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_entrance() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'entrance',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_document
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_document() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' AND NEW.is_validated = true then
+SELECT tdesc.title INTO entity_name FROM t_description tdesc WHERE tdesc.id_document = NEW.id LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        name
+    )
+VALUES (
+        'document',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_history
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_history() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'history',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_location
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_location() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'location',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_comment
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_comment() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'comment',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_description
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_description() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE type_related_entity varchar(20);
+DECLARE id_related_entity int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' AND NEW.id_document is null then
+if NEW.id_cave is not null then
+type_related_entity := 'cave';
+id_related_entity := NEW.id_cave;
+elsif NEW.id_entrance is not null then
+type_related_entity := 'entrance';
+id_related_entity := NEW.id_entrance;
+elsif NEW.id_massif is not null then
+type_related_entity := 'massif';
+id_related_entity := NEW.id_massif;
+end if;
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND (tname.id_cave = NEW.id_cave OR tname.id_entrance = NEW.id_entrance OR tname.id_massif = NEW.id_massif) LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'description',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- change_rigging
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION change_rigging() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'rigging',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -529,6 +529,220 @@ DROP TRIGGER IF EXISTS last_change_comment ON t_comment;
 CREATE TRIGGER last_change_comment BEFORE INSERT OR UPDATE ON t_comment FOR EACH ROW EXECUTE PROCEDURE change_comment();
 `;
 
+const CREATE_SUB_ENTITY_TRIGGERS = `
+CREATE OR REPLACE FUNCTION change_history() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'history',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS last_change_history ON t_history;
+CREATE TRIGGER last_change_history BEFORE INSERT OR UPDATE ON t_history FOR EACH ROW EXECUTE PROCEDURE change_history();
+
+CREATE OR REPLACE FUNCTION change_location() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'location',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS last_change_location ON t_location;
+CREATE TRIGGER last_change_location BEFORE INSERT OR UPDATE ON t_location FOR EACH ROW EXECUTE PROCEDURE change_location();
+
+CREATE OR REPLACE FUNCTION change_description() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE type_related_entity varchar(20);
+DECLARE id_related_entity int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' AND NEW.id_document is null then
+if NEW.id_cave is not null then
+type_related_entity := 'cave';
+id_related_entity := NEW.id_cave;
+elsif NEW.id_entrance is not null then
+type_related_entity := 'entrance';
+id_related_entity := NEW.id_entrance;
+elsif NEW.id_massif is not null then
+type_related_entity := 'massif';
+id_related_entity := NEW.id_massif;
+end if;
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND (tname.id_cave = NEW.id_cave OR tname.id_entrance = NEW.id_entrance OR tname.id_massif = NEW.id_massif) LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'description',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS last_change_description ON t_description;
+CREATE TRIGGER last_change_description BEFORE INSERT OR UPDATE ON t_description FOR EACH ROW EXECUTE PROCEDURE change_description();
+
+CREATE OR REPLACE FUNCTION change_rigging() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'rigging',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS last_change_rigging ON t_rigging;
+CREATE TRIGGER last_change_rigging BEFORE INSERT OR UPDATE ON t_rigging FOR EACH ROW EXECUTE PROCEDURE change_rigging();
+`;
+
 const ADMIN_MFA_MIGRATION = `
 ALTER TABLE t_caver ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(255) DEFAULT NULL;
 ALTER TABLE t_caver ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN NOT NULL DEFAULT false;
@@ -554,4 +768,5 @@ module.exports = {
   CONVERT_MEASUREMENT_TO_PARTITIONED,
   CREATE_GUIDELINE_TRIGGERS,
   CREATE_COMMENT_TRIGGERS,
+  CREATE_SUB_ENTITY_TRIGGERS,
 };

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -477,6 +477,58 @@ DROP TRIGGER IF EXISTS last_change_guideline ON t_guideline;
 CREATE TRIGGER last_change_guideline BEFORE INSERT OR UPDATE ON t_guideline FOR EACH ROW EXECUTE PROCEDURE change_guideline();
 `;
 
+const CREATE_COMMENT_TRIGGERS = `
+CREATE OR REPLACE FUNCTION change_comment() RETURNS trigger AS $$
+DECLARE type_change varchar(20);
+DECLARE id_author int4;
+DECLARE entity_name text;
+BEGIN
+IF current_setting('app.relevance_swap_skip_log', true) = 'true' THEN RETURN NEW; END IF;
+type_change := '';
+if NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = true then
+    type_change := 'delete';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif NEW.is_deleted != OLD.is_deleted AND NEW.is_deleted = false then
+    type_change := 'restore';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+elsif TG_OP = 'INSERT' then
+    type_change := 'create';
+    id_author := NEW.id_author;
+elsif NEW.is_deleted = false then
+    type_change := 'update';
+    id_author := COALESCE(NEW.id_reviewer, NEW.id_author);
+end if;
+if type_change != '' then
+SELECT tname.name INTO entity_name FROM t_name tname WHERE tname.is_main = true AND tname.id_entrance = NEW.id_entrance LIMIT 1;
+INSERT INTO t_last_change (
+        type_entity,
+        type_change,
+        date_change,
+        id_entity,
+        id_author,
+        type_related_entity,
+        id_related_entity,
+        name
+    )
+VALUES (
+        'comment',
+        type_change,
+        now(),
+        NEW.id,
+        id_author,
+        'entrance',
+        NEW.id_entrance,
+        entity_name
+    );
+end if;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS last_change_comment ON t_comment;
+CREATE TRIGGER last_change_comment BEFORE INSERT OR UPDATE ON t_comment FOR EACH ROW EXECUTE PROCEDURE change_comment();
+`;
+
 const ADMIN_MFA_MIGRATION = `
 ALTER TABLE t_caver ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(255) DEFAULT NULL;
 ALTER TABLE t_caver ADD COLUMN IF NOT EXISTS mfa_enabled BOOLEAN NOT NULL DEFAULT false;
@@ -501,4 +553,5 @@ module.exports = {
   ADMIN_MFA_MIGRATION,
   CONVERT_MEASUREMENT_TO_PARTITIONED,
   CREATE_GUIDELINE_TRIGGERS,
+  CREATE_COMMENT_TRIGGERS,
 };

--- a/test/fixtures/tcomment.json
+++ b/test/fixtures/tcomment.json
@@ -62,5 +62,27 @@
     "body": "Body comment 4",
     "entrance": 2,
     "language": "fra"
+  },
+  {
+    "_comment": "Issue #1772 fixture: old comment on entrance 999 by moderator (id=2), no reviewer — used to verify relevance-swap does not corrupt recent-changes",
+    "id": 5,
+    "author": 2,
+    "dateInscription": "2010-03-01T10:00:00.000Z",
+    "relevance": 1,
+    "title": "Old comment A (entrance 999)",
+    "body": "Body old comment A",
+    "entrance": 999,
+    "language": "fra"
+  },
+  {
+    "_comment": "Issue #1772 fixture: second old comment on entrance 999 by moderator (id=2), no reviewer",
+    "id": 6,
+    "author": 2,
+    "dateInscription": "2011-05-15T14:00:00.000Z",
+    "relevance": 2,
+    "title": "Old comment B (entrance 999)",
+    "body": "Body old comment B",
+    "entrance": 999,
+    "language": "fra"
   }
 ]

--- a/test/integration/4_routes/Changes/get-recent-comment-relevance-swap.test.js
+++ b/test/integration/4_routes/Changes/get-recent-comment-relevance-swap.test.js
@@ -1,0 +1,208 @@
+/**
+ * Regression test for issue #1772:
+ * "Reordering a newly created comment corrupts the recent changes feed"
+ *
+ * Root cause (fixed):
+ *   The change_comment() DB trigger classified any UPDATE on an unreviewed
+ *   comment (id_reviewer IS NULL) as type_change='create', attributing it to
+ *   the row's original author.  This meant a relevance swap — which is a pure
+ *   UPDATE that never sets id_reviewer — incorrectly logged the displaced old
+ *   comment as newly created by its original author.
+ *
+ *   Fix: use TG_OP='INSERT' to guard the 'create' branch in all change_*()
+ *   trigger functions, matching the already-correct change_guideline() pattern.
+ *   An UPDATE falls through to the 'update' branch regardless of id_reviewer.
+ *
+ * Scenario (entrance 999, two pre-existing fixture comments by moderator):
+ *   1. user1 creates a new comment  → appended at bottom (highest relevance)
+ *   2. user1 moves it up twice      → swaps past both fixture comments 6 and 5
+ *   3. user1 edits the new comment  → sets id_reviewer
+ *   4. GET /api/v1/changes/recent   → inspect the groups for entrance 999
+ *
+ * Expected (correct) behaviour after fix:
+ *   - user1 appears once with subAction='create'
+ *   - moderator does not appear (they took no action)
+ */
+const supertest = require('supertest');
+const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
+
+describe('Changes - GET /api/v1/changes/recent', () => {
+  describe('Issue #1772 — relevance swap must not corrupt recent changes', () => {
+    let userToken;
+    // Captured from the create response — all subsequent steps reference this.
+    let newCommentId;
+
+    before(async () => {
+      userToken = await AuthTokenService.getRawBearerUserToken();
+    });
+
+    // ── Step 1: create a new comment as user1 ────────────────────────────────
+    it('should create a new comment on entrance 999 (user1)', (done) => {
+      supertest(sails.hooks.http.app)
+        .post('/api/v1/comments')
+        .send({
+          entrance: 999,
+          title: 'New comment by user1',
+          body: 'Will be moved up.',
+          language: 'eng',
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            should(res.body).have.property('id');
+            // New comment lands at the bottom: its relevance must be greater
+            // than both fixture comments (rel 1 and 2).
+            should(res.body.relevance).be.greaterThan(2);
+            newCommentId = res.body.id;
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    // ── Step 2a: move up — swaps new comment with next lower neighbor ─────────
+    it('should move the new comment up once (swap with immediate lower neighbor)', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch(`/api/v1/comments/${newCommentId}/move-relevance`)
+        .send({ direction: -1 })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            should(res.body).have.property('moved');
+            should(res.body.moved.id).equal(newCommentId);
+            // Moved comment took the neighbor's relevance (lower value).
+            should(res.body).have.property('swapped');
+            should(res.body.swapped.relevance).be.greaterThan(
+              res.body.moved.relevance
+            );
+            // The trigger's skip-log guard (app.relevance_swap_skip_log) now
+            // prevents the displaced comment from generating a spurious 'create'
+            // event for its original author.
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    // ── Step 2b: move up again — swaps with fixture comment at relevance 1 ───
+    it('should move the new comment up again past one of the fixture comments', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch(`/api/v1/comments/${newCommentId}/move-relevance`)
+        .send({ direction: -1 })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            should(res.body).have.property('moved');
+            should(res.body.moved.id).equal(newCommentId);
+            should(res.body).have.property('swapped');
+            should(res.body.swapped.relevance).be.greaterThan(
+              res.body.moved.relevance
+            );
+            // The skip-log guard prevents this second displaced comment from
+            // generating a spurious event as well.
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    // ── Step 3: edit the new comment within the 6h grouping window ────────────
+    it('should edit the new comment (sets id_reviewer, obscures original create event)', (done) => {
+      supertest(sails.hooks.http.app)
+        .patch(`/api/v1/comments/${newCommentId}`)
+        .send({
+          title: 'New comment by user1 (edited)',
+          body: 'Edited body.',
+          language: 'eng',
+        })
+        .set('Authorization', userToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            should(res.body.title).equal('New comment by user1 (edited)');
+            should(res.body.reviewer).have.property('id');
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+
+    // ── Step 4: assert recent-changes output ──────────────────────────────────
+    it('should reflect the correct actors and actions in the recent-changes feed for entrance 999', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/changes/recent')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            const { changes } = res.body;
+            should(changes).be.an.Array();
+
+            const entrance999Groups = changes.filter(
+              (c) => c.mainEntityId === 999
+            );
+
+            // ── user1's contribution ───────────────────────────────────────
+            const user1Groups = entrance999Groups.filter(
+              (c) => c.author === 'User1'
+            );
+
+            should(user1Groups).have.length(
+              1,
+              'user1 must appear exactly once in recent changes for entrance 999'
+            );
+
+            // user1 created the new comment and later edited it within the 6h
+            // window. The trigger now uses TG_OP='INSERT' for 'create', so the
+            // edit (an UPDATE) is classified as 'update'. groupChanges() gives
+            // 'create' priority over 'update' within the same group, so the
+            // contribution correctly surfaces as 'create'.
+            should(user1Groups[0].subAction).equal(
+              'create',
+              'user1 new comment must appear as "create" in recent changes'
+            );
+
+            // ── displaced old fixture comments must NOT appear ─────────────
+            const moderatorGroups = entrance999Groups.filter(
+              (c) => c.author === 'Moderator1'
+            );
+
+            // Relevance swaps are UPDATEs. With TG_OP='INSERT' guarding the
+            // 'create' branch, a swap on an unreviewed comment now falls into
+            // the 'update' branch. groupChanges() groups those updates under
+            // the actor who triggered the move (user1), not the displaced
+            // comment's original author (moderator). Moderator took no action.
+            should(moderatorGroups.length).equal(
+              0,
+              'moderator must not appear in recent changes — they took no action'
+            );
+
+            return done();
+          } catch (testErr) {
+            return done(testErr);
+          }
+        });
+    });
+  });
+});

--- a/test/seed-database.js
+++ b/test/seed-database.js
@@ -78,6 +78,7 @@ async function seedDatabase({ testUrl }) {
                 customSQL.DROP_HISTORY_PARENT_FK_CONSTRAINTS,
                 customSQL.ADMIN_MFA_MIGRATION,
                 customSQL.CREATE_GUIDELINE_TRIGGERS,
+                customSQL.CREATE_COMMENT_TRIGGERS,
               ].join('\n')
             )
               .then(() => resolve(sails))

--- a/test/seed-database.js
+++ b/test/seed-database.js
@@ -79,6 +79,7 @@ async function seedDatabase({ testUrl }) {
                 customSQL.ADMIN_MFA_MIGRATION,
                 customSQL.CREATE_GUIDELINE_TRIGGERS,
                 customSQL.CREATE_COMMENT_TRIGGERS,
+                customSQL.CREATE_SUB_ENTITY_TRIGGERS,
               ].join('\n')
             )
               .then(() => resolve(sails))


### PR DESCRIPTION
Fixes the three bugs described in #1772 that caused relevance swaps to corrupt the recent changes feed.

## Why

Reordering a sub-entity (comment, description, rigging, etc.) via the relevance controls produced two symptoms visible in `GET /api/v1/changes/recent`:

- Displaced old sub-entities appeared as `create` events attributed to their original authors, even though those authors took no action.
- The real creation of the newly-reordered sub-entity was obscured and surfaced as `change` instead of `create`.

## What

**`sql/1_2026_08_17_fix_change_triggers.sql`** — incremental migration replacing all ten `change_*()` trigger functions with two fixes:

1. Replace `NEW.id_reviewer IS NULL` with `TG_OP = 'INSERT'` as the `create` guard. An UPDATE caused by a relevance swap is never an INSERT, so it no longer misclassifies as `create`. Mirrors the already-correct `change_guideline()` pattern.
2. Add a `current_setting('app.relevance_swap_skip_log', true)` guard at the top of each function. `RelevanceService` sets this flag via `SET LOCAL` for the neighbor-only update inside the swap transaction, so the involuntary side-effect produces no `t_last_change` entry at all. Same pattern as the pre-existing `app.is_enrichment` flag in `EnrichmentQueueService`.

**`api/services/RelevanceService.js`** — the neighbor relevance update now uses raw SQL with `SET LOCAL app.relevance_swap_skip_log = 'true'` so the trigger skips logging for it. The target entity's update still goes through Waterline and is logged normally.

**`api/services/RecentChangeService.js`** — `groupChanges()` gains same-entity priority logic for sub-actions: when the same sub-entity id produced both a `create` and a later `update` within the grouping window (i.e. created then edited), `create` takes priority over `update`. Mixed actions across different sub-entity ids still correctly resolve to `change`.

**`api/models/TLastChange.js`** — fixed `entityRelatedType` from `type: 'number'` to `type: 'string'` / `columnType: 'varchar(30)'` to match the production schema.

**Test files** — regression test covering the full scenario (create → move × 2 → edit → assert recent changes), fixture comments for entrance 999, and `CREATE_COMMENT_TRIGGERS` in `customSQL.js` to install `change_comment` / `last_change_comment` in the test DB.

## Related

- Issue: https://github.com/GrottoCenter/grottocenter-api/issues/1772
