### PR TITLE
fix(document): prevent cyclic parent relationships

### DIFF
--- a/api/controllers/v1/document/multiple-validate.js
+++ b/api/controllers/v1/document/multiple-validate.js
@@ -70,6 +70,41 @@ async function validateAndUpdateDocument(
   const { scalarData, collectionData } =
     normalizeAndSplitDocumentData(documentData);
 
+  // Re-validate the parent assignment against the current hierarchy.
+  // The hierarchy may have changed since the modification was submitted
+  // (e.g. a sibling was re-parented while this modification was pending),
+  // so the stored parent could now create a cycle even though it passed
+  // validation at submission time.
+  // Also re-apply the type-vs-parent policy in case the stored type no
+  // longer allows a parent (uses the stored type with a fallback to the
+  // current document type, matching the update-with-new-entities.js path).
+  const effectiveTypeId = scalarData.type ?? document.type;
+  scalarData.parent = DocumentService.clearParentIfTypeDisallows(
+    effectiveTypeId,
+    scalarData.parent
+  );
+  if (scalarData.parent != null) {
+    const parentError = await DocumentService.validateParentAssignment(
+      document.id,
+      scalarData.parent
+    );
+    if (parentError) {
+      // Reject the modification rather than persisting a corrupt hierarchy.
+      // Clear the pending modification so the document returns to its last
+      // validated state and the moderator is informed of why it was rejected.
+      await TDocument.updateOne(document.id).set({
+        modifiedDocJson: null,
+        validationComment: `Auto-rejected: ${parentError}`,
+        validator: validationAuthor,
+        dateValidation: new Date(),
+      });
+      sails.log.warn(
+        `Document ${document.id} modification auto-rejected: ${parentError}`
+      );
+      return { rejected: true, reason: `Auto-rejected: ${parentError}` };
+    }
+  }
+
   await sails.getDatastore().transaction(async (db) => {
     // Update associated data not handled by TDocument manually
     // Updated before the TDocument update so the last_change_document DB trigger will fetch the last updated name
@@ -120,6 +155,7 @@ async function validateAndUpdateDocument(
     }
     await Promise.all(filePromises);
   });
+  return { rejected: false };
 }
 
 async function updateSearchAndNotify(req, documentId, userId) {
@@ -204,11 +240,34 @@ module.exports = async (req, res) => {
 
     if (isAModifiedDoc) {
       // eslint-disable-next-line no-await-in-loop
-      await validateAndUpdateDocument(
+      const result = await validateAndUpdateDocument(
         document,
         change.validationComment,
         req.token.id
       );
+      if (result.rejected) {
+        // The pending modification was auto-rejected due to a parent cycle.
+        // Send a REJECT author notification with the auto-rejection reason,
+        // matching the behaviour of the manual-rejection path above.
+        // eslint-disable-next-line no-await-in-loop
+        const rejectedDoc = await DocumentService.getPopulatedDocument(
+          document.id
+        );
+        // eslint-disable-next-line no-await-in-loop
+        await NotificationService.notifyAuthor(
+          rejectedDoc,
+          req.token.id,
+          NotificationService.NOTIFICATION_TYPES.REJECT,
+          result.reason
+        ).catch((err) =>
+          sails.log.error(
+            'Document multiple-validate notifyAuthor error',
+            document,
+            err
+          )
+        );
+        continue; // eslint-disable-line no-continue
+      }
     } else {
       // Likely a document creation
       // eslint-disable-next-line no-await-in-loop

--- a/api/controllers/v1/document/update-with-new-entities.js
+++ b/api/controllers/v1/document/update-with-new-entities.js
@@ -42,20 +42,27 @@ module.exports = async (req, res) => {
   // Reject cyclic parent assignments before touching any data.
   // scalarData.parent may be a raw ID or an object with an id property.
   const rawParent = scalarData.parent;
-  const proposedParentId =
+  const resolvedParent =
     rawParent != null && typeof rawParent === 'object'
       ? rawParent.id
       : rawParent;
+
+  // Apply the same type-vs-parent policy as getConvertedDataFromClient:
+  // if the type does not allow a parent, clear it now so the ORM write
+  // does not preserve a stale id_parent from a previous type state.
+  const effectiveTypeId = scalarData.type ?? currentDocument.type;
+  scalarData.parent = DocumentService.clearParentIfTypeDisallows(
+    effectiveTypeId,
+    resolvedParent
+  );
+
+  const proposedParentId = scalarData.parent;
   if (proposedParentId != null) {
-    const hasCycle = await DocumentService.checkParentCycle(
-      Number(documentId),
-      Number(proposedParentId)
+    const parentError = await DocumentService.validateParentAssignment(
+      documentId,
+      proposedParentId
     );
-    if (hasCycle) {
-      return res.badRequest(
-        'The proposed parent would create a cycle in the document hierarchy.'
-      );
-    }
+    if (parentError) return res.badRequest(parentError);
   }
 
   // Wrap the scalar update, entity creation, and all replaceCollection calls in

--- a/api/controllers/v1/document/update-with-new-entities.js
+++ b/api/controllers/v1/document/update-with-new-entities.js
@@ -39,6 +39,25 @@ module.exports = async (req, res) => {
     }
   }
 
+  // Reject cyclic parent assignments before touching any data.
+  // scalarData.parent may be a raw ID or an object with an id property.
+  const rawParent = scalarData.parent;
+  const proposedParentId =
+    rawParent != null && typeof rawParent === 'object'
+      ? rawParent.id
+      : rawParent;
+  if (proposedParentId != null) {
+    const hasCycle = await DocumentService.checkParentCycle(
+      Number(documentId),
+      Number(proposedParentId)
+    );
+    if (hasCycle) {
+      return res.badRequest(
+        'The proposed parent would create a cycle in the document hierarchy.'
+      );
+    }
+  }
+
   // Wrap the scalar update, entity creation, and all replaceCollection calls in
   // a single transaction so the document is never left in a partially-updated state.
   let updatedDocument;

--- a/api/controllers/v1/document/update.js
+++ b/api/controllers/v1/document/update.js
@@ -45,18 +45,18 @@ module.exports = async (req, res) => {
   }
 
   // Reject cyclic parent assignments before any file upload side-effects.
+  documentDataForValidation.parent = DocumentService.clearParentIfTypeDisallows(
+    effectiveType,
+    documentDataForValidation.parent
+  );
   const proposedParentId = documentDataForValidation.parent;
   if (proposedParentId != null) {
     const documentId = req.param('id');
-    const hasCycle = await DocumentService.checkParentCycle(
-      Number(documentId),
-      Number(proposedParentId)
+    const parentError = await DocumentService.validateParentAssignment(
+      documentId,
+      proposedParentId
     );
-    if (hasCycle) {
-      return res.badRequest(
-        'The proposed parent would create a cycle in the document hierarchy.'
-      );
-    }
+    if (parentError) return res.badRequest(parentError);
   }
 
   // Add new files

--- a/api/controllers/v1/document/update.js
+++ b/api/controllers/v1/document/update.js
@@ -44,6 +44,21 @@ module.exports = async (req, res) => {
     );
   }
 
+  // Reject cyclic parent assignments before any file upload side-effects.
+  const proposedParentId = documentDataForValidation.parent;
+  if (proposedParentId != null) {
+    const documentId = req.param('id');
+    const hasCycle = await DocumentService.checkParentCycle(
+      Number(documentId),
+      Number(proposedParentId)
+    );
+    if (hasCycle) {
+      return res.badRequest(
+        'The proposed parent would create a cycle in the document hierarchy.'
+      );
+    }
+  }
+
   // Add new files
   const newFiles = [];
   if (req.files && req.files.files) {

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -8,7 +8,11 @@ const {
   valIfTruthyOrNull,
   distantFileDownload,
 } = require('../utils/csvHelper');
-const { DOCUMENT_M2M_COLLECTIONS } = require('../../config/constants/document');
+const {
+  DOCUMENT_M2M_COLLECTIONS,
+  TYPES_ALLOWING_PARENT,
+  TYPES_REQUIRING_PARENT,
+} = require('../../config/constants/document');
 
 // Normalize a collection value to a plain ID (handles both raw IDs and objects).
 const normalizeToId = (item) =>
@@ -190,7 +194,14 @@ module.exports = {
       // regions: body.regions?.map((r) => r.id), // Deprecated
       isoRegions,
       countries,
-      parent: body.parent?.id,
+      // When a type is provided and it doesn't allow a parent, explicitly clear
+      // the parent field regardless of whether the client sent it. This prevents
+      // a stale id_parent from surviving a type change (e.g. Issue → Collection)
+      // when the front-end omits the parent field instead of sending null.
+      parent:
+        typeFound && !TYPES_ALLOWING_PARENT.includes(typeFound.id)
+          ? null
+          : body.parent?.id,
       // children cannot be set. The parent child relation can only be changed in one direction
       authorizationDocument: body.authorizationDocument?.id,
     };
@@ -324,19 +335,14 @@ module.exports = {
     descriptionData,
     shouldDownloadDistantFile = false
   ) => {
-    // Doc types needing a parent in order to be created
-    // (ex; an issue needs a collection, an article needs an issue)
-    const MANDATORY_PARENT_TYPES = ['article', 'issue'];
-
     const document = await sails.getDatastore().transaction(async (db) => {
       // Perform some checks
       const docType =
         documentData.type && (await TType.findOne(documentData.type));
       if (docType) {
-        const docTypeName = docType.name.toLowerCase();
         // Parent doc is mandatory for articles and issues
         if (
-          MANDATORY_PARENT_TYPES.includes(docTypeName) &&
+          TYPES_REQUIRING_PARENT.includes(docType.id) &&
           !documentData.parent
         ) {
           throw Error(
@@ -549,10 +555,9 @@ module.exports = {
   getCollectionAncestors: async (documentIds) => {
     if (documentIds.length === 0) return [];
 
-    // Infinite loop should normaly not happen unless the t_document table is not properly formated as a tree
-    // In case it happend search for:
-    // - Self reference: SELECT id, id_parent FROM t_document WHERE id = id_parent;
-    // - Cycle: A → B → A
+    // The CYCLE clause (PostgreSQL 14+) detects when a row has already appeared
+    // in the recursive path and stops traversal, so cyclic data (e.g. a document
+    // that is its own parent) can never produce an infinite loop.
     const query = `
       WITH RECURSIVE doc_hierarchy AS (
         SELECT id, id_parent, id_type
@@ -565,16 +570,61 @@ module.exports = {
         FROM t_document d
         JOIN doc_hierarchy dh ON d.id = dh.id_parent
       )
+      CYCLE id SET is_cycle USING path
       SELECT DISTINCT dh.id
       FROM doc_hierarchy dh
       JOIN t_type t ON dh.id_type = t.id
       WHERE t.name = 'Collection'
+        AND dh.is_cycle = false
     `;
 
     const result = await sails.sendNativeQuery(query, [documentIds]);
     const collectionIds = result.rows.map((row) => row.id);
 
     return module.exports.getDocuments(collectionIds);
+  },
+
+  /**
+   * Check whether setting `proposedParentId` as the parent of `documentId`
+   * would create a cycle in the document hierarchy.
+   *
+   * Returns true when a cycle would be created (i.e. documentId already
+   * appears in the ancestor chain of proposedParentId, or they are the same).
+   *
+   * @param {number} documentId       - the document being updated
+   * @param {number} proposedParentId - the candidate new parent
+   * @returns {Promise<boolean>}
+   */
+  checkParentCycle: async (documentId, proposedParentId) => {
+    if (documentId === proposedParentId) return true;
+
+    // Walk the ancestor chain of proposedParentId upward.  If documentId
+    // appears anywhere along that chain, the assignment would create a cycle.
+    const query = `
+      WITH RECURSIVE ancestors AS (
+        SELECT id, id_parent
+        FROM t_document
+        WHERE id = $1
+
+        UNION ALL
+
+        SELECT d.id, d.id_parent
+        FROM t_document d
+        JOIN ancestors a ON d.id = a.id_parent
+      )
+      CYCLE id SET is_cycle USING path
+      SELECT 1
+      FROM ancestors
+      WHERE id = $2
+        AND is_cycle = false
+      LIMIT 1
+    `;
+
+    const result = await sails.sendNativeQuery(query, [
+      proposedParentId,
+      documentId,
+    ]);
+    return result.rows.length > 0;
   },
 
   normalizeToId,

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -627,8 +627,51 @@ module.exports = {
     return result.rows.length > 0;
   },
 
-  normalizeToId,
-  mapAuthorsOrganizationForSearch,
+  /**
+   * Validate that setting proposedParentId as the parent of documentId is safe:
+   * both ids must be finite integers and the assignment must not create a cycle.
+   *
+   * Returns an error message string if the assignment is invalid, or null if it
+   * is safe to proceed. Controllers call this and return res.badRequest(msg) on
+   * a non-null result.
+   *
+   * @param {number} documentId
+   * @param {number} proposedParentId
+   * @returns {Promise<string|null>}
+   */
+  async validateParentAssignment(documentId, proposedParentId) {
+    const numDocId = Number(documentId);
+    const numParentId = Number(proposedParentId);
+    if (!Number.isInteger(numDocId) || !Number.isInteger(numParentId)) {
+      return 'Document id and parent id must be integers.';
+    }
+    const hasCycle = await module.exports.checkParentCycle(
+      numDocId,
+      numParentId
+    );
+    if (hasCycle) {
+      return 'The proposed parent would create a cycle in the document hierarchy.';
+    }
+    return null;
+  },
+
+  /**
+   * If the given type ID does not allow a parent, return null to explicitly
+   *
+   * Centralises the "type-vs-parent" policy so both update paths enforce the
+   * same rule: update.js (via getConvertedDataFromClient) and
+   * update-with-new-entities.js (which writes scalarData directly).
+   *
+   * @param {number|undefined} typeId        - resolved type id (may be undefined)
+   * @param {number|null|undefined} parentId - current proposed parent value
+   * @returns {number|null|undefined}
+   */
+  clearParentIfTypeDisallows: (typeId, parentId) => {
+    if (typeId != null && !TYPES_ALLOWING_PARENT.includes(typeId)) {
+      return null;
+    }
+    return parentId;
+  },
 
   /**
    * Replace all m2m collections that are explicitly present in collectionData.
@@ -653,4 +696,7 @@ module.exports = {
     );
     await Promise.all(promises);
   },
+
+  normalizeToId,
+  mapAuthorsOrganizationForSearch,
 };

--- a/config/constants/document.js
+++ b/config/constants/document.js
@@ -17,16 +17,17 @@ const TYPES_ALLOWING_ISSUE = [DOCUMENT_TYPE_IDS.BOOK, DOCUMENT_TYPE_IDS.ISSUE];
 // Document types that may have a parent document set.
 // An Issue must be under a Collection; an Article must be under an Issue.
 // All other types are top-level and must not have a parent.
+// Currently every type that may have a parent also requires one, so
+// TYPES_REQUIRING_PARENT is an alias for this same set. If a future type
+// makes the parent optional, split these into two distinct arrays.
 const TYPES_ALLOWING_PARENT = [
   DOCUMENT_TYPE_IDS.ISSUE,
   DOCUMENT_TYPE_IDS.ARTICLE,
 ];
 
-// Document types for which a parent is mandatory at creation time.
-const TYPES_REQUIRING_PARENT = [
-  DOCUMENT_TYPE_IDS.ISSUE,
-  DOCUMENT_TYPE_IDS.ARTICLE,
-];
+// Alias: every type that currently allows a parent also requires one.
+// See comment on TYPES_ALLOWING_PARENT above before diverging these.
+const TYPES_REQUIRING_PARENT = [...TYPES_ALLOWING_PARENT];
 
 /**
  * The seven many-to-many associations on TDocument that must be managed via

--- a/config/constants/document.js
+++ b/config/constants/document.js
@@ -14,6 +14,20 @@ const DOCUMENT_TYPE_IDS = {
 // Matches the t_document_check constraint in sql/0_tables.sql.
 const TYPES_ALLOWING_ISSUE = [DOCUMENT_TYPE_IDS.BOOK, DOCUMENT_TYPE_IDS.ISSUE];
 
+// Document types that may have a parent document set.
+// An Issue must be under a Collection; an Article must be under an Issue.
+// All other types are top-level and must not have a parent.
+const TYPES_ALLOWING_PARENT = [
+  DOCUMENT_TYPE_IDS.ISSUE,
+  DOCUMENT_TYPE_IDS.ARTICLE,
+];
+
+// Document types for which a parent is mandatory at creation time.
+const TYPES_REQUIRING_PARENT = [
+  DOCUMENT_TYPE_IDS.ISSUE,
+  DOCUMENT_TYPE_IDS.ARTICLE,
+];
+
 /**
  * The seven many-to-many associations on TDocument that must be managed via
  * `replaceCollection()`. Waterline silently ignores collection fields when they
@@ -42,5 +56,7 @@ const DOCUMENT_M2M_COLLECTIONS = [
 module.exports = {
   DOCUMENT_TYPE_IDS,
   TYPES_ALLOWING_ISSUE,
+  TYPES_ALLOWING_PARENT,
+  TYPES_REQUIRING_PARENT,
   DOCUMENT_M2M_COLLECTIONS,
 };

--- a/sql/9_20_2026_08_18_document_no_self_parent_constraint.sql
+++ b/sql/9_20_2026_08_18_document_no_self_parent_constraint.sql
@@ -4,5 +4,15 @@
 -- Indirect cycles (A → B → A) are handled at the application layer in
 -- DocumentService.checkParentCycle(); this constraint catches the direct
 -- self-reference case at the database level as a safety net.
-ALTER TABLE t_document
-  ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent);
+--
+-- NOT VALID skips the full-table scan at ALTER time so the migration never
+-- aborts on pre-existing self-parented rows.  New and updated rows are
+-- checked immediately once the constraint exists.
+--
+-- VALIDATE CONSTRAINT is intentionally omitted here.  Run it manually in a
+-- follow-up step once ops has confirmed there are no remaining id = id_parent
+-- rows (query: SELECT id FROM t_document WHERE id = id_parent).
+-- Command to validate when ready:
+--   ALTER TABLE t_document VALIDATE CONSTRAINT t_document_no_self_parent;
+ALTER TABLE t_document DROP CONSTRAINT IF EXISTS t_document_no_self_parent;
+ALTER TABLE t_document ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent) NOT VALID;

--- a/sql/9_20_2026_08_18_document_no_self_parent_constraint.sql
+++ b/sql/9_20_2026_08_18_document_no_self_parent_constraint.sql
@@ -1,0 +1,8 @@
+\c grottoce;
+
+-- Prevent a document from referencing itself as its own parent.
+-- Indirect cycles (A → B → A) are handled at the application layer in
+-- DocumentService.checkParentCycle(); this constraint catches the direct
+-- self-reference case at the database level as a safety net.
+ALTER TABLE t_document
+  ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent);

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -191,10 +191,12 @@ CREATE INDEX IF NOT EXISTS idx_job_batch_status ON t_job_batch (status);
 
 -- Prevent a document from referencing itself as its own parent (mirrors migration
 -- 9_20_2026_08_18_document_no_self_parent_constraint.sql).
+-- The test DB is always fresh so VALIDATE is safe to run immediately here.
 ALTER TABLE t_document
   DROP CONSTRAINT IF EXISTS t_document_no_self_parent;
 ALTER TABLE t_document
-  ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent);
+  ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent) NOT VALID;
+ALTER TABLE t_document VALIDATE CONSTRAINT t_document_no_self_parent;
 `;
 
 // Convert t_measurement from a regular table (created by Waterline migrate:drop)

--- a/test/customSQL.js
+++ b/test/customSQL.js
@@ -188,6 +188,13 @@ CREATE INDEX IF NOT EXISTS idx_h_document_id_massif ON h_document(id_massif);
 -- Job batch indexes
 CREATE INDEX IF NOT EXISTS idx_job_batch_initiator ON t_job_batch (id_initiator);
 CREATE INDEX IF NOT EXISTS idx_job_batch_status ON t_job_batch (status);
+
+-- Prevent a document from referencing itself as its own parent (mirrors migration
+-- 9_20_2026_08_18_document_no_self_parent_constraint.sql).
+ALTER TABLE t_document
+  DROP CONSTRAINT IF EXISTS t_document_no_self_parent;
+ALTER TABLE t_document
+  ADD CONSTRAINT t_document_no_self_parent CHECK (id <> id_parent);
 `;
 
 // Convert t_measurement from a regular table (created by Waterline migrate:drop)

--- a/test/integration/1_services/DocumentService.test.js
+++ b/test/integration/1_services/DocumentService.test.js
@@ -723,6 +723,31 @@ describe('DocumentService', () => {
     });
   });
 
+  describe('validateParentAssignment()', () => {
+    it('should return an error message for a decimal document id', async () => {
+      const result = await DocumentService.validateParentAssignment(1.5, 2);
+      should(result).be.a.String();
+      should(result).match(/integer/i);
+    });
+
+    it('should return an error message for a decimal parent id', async () => {
+      const result = await DocumentService.validateParentAssignment(1, 2.7);
+      should(result).be.a.String();
+      should(result).match(/integer/i);
+    });
+
+    it('should return an error message for a self-reference', async () => {
+      const result = await DocumentService.validateParentAssignment(1, 1);
+      should(result).be.a.String();
+    });
+
+    it('should return null for a valid parent assignment', async () => {
+      // doc 4 (Article) → doc 1 (Collection): no cycle
+      const result = await DocumentService.validateParentAssignment(4, 1);
+      should(result).be.null();
+    });
+  });
+
   describe('getCollectionAncestors() - cycle safety', () => {
     let cyclicDocAId;
     let cyclicDocBId;
@@ -814,7 +839,7 @@ describe('DocumentService', () => {
       should(result.parent).be.null();
     });
 
-    it('should leave parent undefined when no type is given', async () => {
+    it('should return the client-sent parent id when no type is given', async () => {
       const body = {
         parent: { id: 1 },
       };

--- a/test/integration/1_services/DocumentService.test.js
+++ b/test/integration/1_services/DocumentService.test.js
@@ -690,4 +690,137 @@ describe('DocumentService', () => {
       should(result[1].description.title).equal('Desc1');
     });
   });
+
+  describe('checkParentCycle()', () => {
+    // Test documents from fixtures:
+    // id=1  → Collection (no parent)
+    // id=2  → Issue, parent=1
+    // id=3  → Issue, parent=1
+    // id=4  → Article, parent=3
+
+    it('should return true for a direct self-reference', async () => {
+      const result = await DocumentService.checkParentCycle(1, 1);
+      should(result).be.true();
+    });
+
+    it('should return false when there is no cycle (child of existing doc)', async () => {
+      // Setting parent of doc 4 to doc 1 — valid hierarchy, no cycle
+      const result = await DocumentService.checkParentCycle(4, 1);
+      should(result).be.false();
+    });
+
+    it('should return true for an indirect cycle (ancestor → descendant)', async () => {
+      // doc 1 is an ancestor of doc 4 (1 → 3 → 4).
+      // Trying to make doc 1 a child of doc 4 would create a cycle.
+      const result = await DocumentService.checkParentCycle(1, 4);
+      should(result).be.true();
+    });
+
+    it('should return false for an unrelated document pair', async () => {
+      // doc 2 and doc 4 are siblings; neither is an ancestor of the other
+      const result = await DocumentService.checkParentCycle(2, 4);
+      should(result).be.false();
+    });
+  });
+
+  describe('getCollectionAncestors() - cycle safety', () => {
+    let cyclicDocAId;
+    let cyclicDocBId;
+
+    afterEach(async () => {
+      // Clean up any cyclic docs created for these tests
+      if (cyclicDocBId) {
+        await TDocument.updateOne(cyclicDocBId).set({ parent: null });
+      }
+      if (cyclicDocAId) {
+        await TDocument.updateOne(cyclicDocAId).set({ parent: null });
+        await TDocument.destroy({ id: cyclicDocAId });
+        cyclicDocAId = null;
+      }
+      if (cyclicDocBId) {
+        await TDocument.destroy({ id: cyclicDocBId });
+        cyclicDocBId = null;
+      }
+    });
+
+    it('should terminate and not return the cyclic doc when A→B→A cycle exists', async function terminatesCycleGracefully() {
+      // We create an indirect cycle by temporarily bypassing the application-layer
+      // validation and inserting directly via raw SQL.  This simulates legacy/corrupt
+      // data that may exist in production before the constraint was added.
+      this.timeout(10000);
+
+      // Create doc A (a Collection, so getCollectionAncestors would normally walk up)
+      const docA = await TDocument.create({ author: 1, type: 1 }).fetch();
+      cyclicDocAId = docA.id;
+
+      // Create doc B pointing to doc A as parent
+      const docB = await TDocument.create({
+        author: 1,
+        type: 1,
+        parent: docA.id,
+      }).fetch();
+      cyclicDocBId = docB.id;
+
+      // Form the cycle: A → B by bypassing the CHECK constraint with raw SQL
+      // (constraint was added after legacy data; the CTE must still be safe)
+      await sails.sendNativeQuery(
+        'UPDATE t_document SET id_parent = $1 WHERE id = $2',
+        [docB.id, docA.id]
+      );
+
+      // getCollectionAncestors must terminate and return a valid (possibly empty) array
+      const result = await DocumentService.getCollectionAncestors([
+        docA.id,
+        docB.id,
+      ]);
+      should(result).be.an.Array();
+    });
+  });
+
+  describe('getConvertedDataFromClient() - parent clearing', () => {
+    it('should keep parent when type allows it (Article)', async () => {
+      const body = {
+        type: 'Article',
+        parent: { id: 2 },
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      should(result.parent).equal(2);
+    });
+
+    it('should keep parent when type allows it (Issue)', async () => {
+      const body = {
+        type: 'Issue',
+        parent: { id: 1 },
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      should(result.parent).equal(1);
+    });
+
+    it('should clear parent when type does not allow it (Collection)', async () => {
+      const body = {
+        type: 'Collection',
+        // parent deliberately omitted — simulates front-end FormData omission
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      should(result.parent).be.null();
+    });
+
+    it('should clear parent even when client sends a parent id for a non-parent type', async () => {
+      const body = {
+        type: 'Collection',
+        parent: { id: 1 },
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      should(result.parent).be.null();
+    });
+
+    it('should leave parent undefined when no type is given', async () => {
+      const body = {
+        parent: { id: 1 },
+      };
+      const result = await DocumentService.getConvertedDataFromClient(body);
+      // No type → we cannot determine allowed types; leave the field as-is
+      should(result.parent).equal(1);
+    });
+  });
 });

--- a/test/integration/4_routes/Documents/multiple-validate.test.js
+++ b/test/integration/4_routes/Documents/multiple-validate.test.js
@@ -354,6 +354,100 @@ describe('Document multiple-validate', () => {
         const authorIds = updated.authors.map((a) => a.id);
         should(authorIds).containEql(1);
       });
+
+      it('should auto-reject modifiedDocJson that would create a parent cycle at approval time', async () => {
+        // Set up: docA is the parent of docB.
+        // User submits a modification on docA to set its parent to docB.
+        // This passes validation at submission time if docB is not yet
+        // an ancestor of docA. But by approval time the hierarchy has not
+        // changed — the cycle is detected and the modification is rejected.
+        const desc = await TDescription.create({
+          author: 1,
+          title: 'Cycle test',
+          body: 'Body',
+        }).fetch();
+        createdDescIds.push(desc.id);
+
+        // docA — will have a pending modification that tries to set parent = docB
+        const docA = await TDocument.create({
+          author: 1,
+          type: 1,
+          license: 1,
+          isValidated: false,
+          descriptions: [desc.id],
+        }).fetch();
+        createdDocIds.push(docA.id);
+
+        // docB — child of docA
+        const docB = await TDocument.create({
+          author: 1,
+          type: 17,
+          license: 1,
+          parent: docA.id,
+          isValidated: true,
+        }).fetch();
+        createdDocIds.push(docB.id);
+
+        // Stage a pending modification on docA that would create cycle docA → docB → docA
+        await TDocument.updateOne(docA.id).set({
+          modifiedDocJson: {
+            reviewerId: 2,
+            documentData: { type: 17, parent: docB.id },
+            descriptionData: { title: 'Cycle test', body: 'Body' },
+          },
+        });
+
+        // Track notifications created during validation
+        const beforeNotifIds = (await TNotification.find().select(['id'])).map(
+          (n) => n.id
+        );
+
+        await supertest(sails.hooks.http.app)
+          .put('/api/v1/documents/validate')
+          .send({
+            documents: [{ id: docA.id, isValidated: 'true' }],
+          })
+          .set('Authorization', moderatorToken)
+          .set('Content-type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(204);
+
+        const updated = await TDocument.findOne(docA.id);
+        // modifiedDocJson must be cleared (auto-rejected)
+        should(updated.modifiedDocJson).be.null();
+        // The cyclic parent must NOT have been written
+        should(updated.parent).not.equal(docB.id);
+        // The auto-rejection comment must be set
+        should(updated.validationComment).match(/auto-rejected/i);
+
+        // No VALIDATE notification must have been sent — only a REJECT one
+        const afterNotifIds = (await TNotification.find().select(['id'])).map(
+          (n) => n.id
+        );
+        const newNotifIds = afterNotifIds.filter(
+          (id) => !beforeNotifIds.includes(id)
+        );
+        const VALIDATE_TYPE_ID = 4;
+        const REJECT_TYPE_ID = 7;
+        const validateNotif = newNotifIds.length
+          ? await TNotification.findOne({
+              id: newNotifIds,
+              notificationType: VALIDATE_TYPE_ID,
+            })
+          : null;
+        should(validateNotif).be.undefined();
+
+        // A REJECT author notification must have been sent with the auto-rejection reason
+        const rejectNotif = newNotifIds.length
+          ? await TNotification.findOne({
+              id: newNotifIds,
+              notified: 1,
+              document: docA.id,
+              notificationType: REJECT_TYPE_ID,
+            })
+          : null;
+        should(rejectNotif).not.be.undefined();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the root causes of the cyclic document parent hang described in #1778. The data fix (clearing id 234218) is already applied in production; this PR prevents the same corruption from happening again and makes existing corrupt data survivable.

## Why

- **`getCollectionAncestors()` could hang indefinitely** when a document's `id_parent` chain formed a cycle (A→A or A→B→A). The recursive CTE used `UNION ALL` with no termination guard, so it looped forever. This caused any org details request that included such a document to time out.
- **No write-time validation** prevented a document from being set as its own parent or creating an indirect cycle. The corruption path was: type change → front-end omits `parent` field → back-end preserved the stale FK.
- **No DB constraint** blocked self-references at the storage level.

## What

- `getCollectionAncestors()` — added `CYCLE id SET is_cycle USING path` (PG 14+) so cyclic rows are detected and skipped instead of looped forever.
- `DocumentService.checkParentCycle()` — new helper that walks the proposed parent's ancestor chain to detect indirect cycles before any write.
- `update.js` and `update-with-new-entities.js` — call `checkParentCycle()` before persisting; return 400 on a cycle.
- `getConvertedDataFromClient()` — when the resolved document type does not allow a parent (`TYPES_ALLOWING_PARENT`), the `parent` field is explicitly set to `null` rather than left `undefined`, so a type change always clears a stale parent regardless of whether the client sends the field.
- `sql/9_20_2026_08_18_document_no_self_parent_constraint.sql` — adds `CHECK (id <> id_parent)` to `t_document`; `test/customSQL.js` mirrors it for the test DB.
- `TYPES_ALLOWING_PARENT` / `TYPES_REQUIRING_PARENT` constants replace the local `MANDATORY_PARENT_TYPES` string array.
- 14 new integration tests covering direct cycles, indirect cycles, unrelated pairs, and the parent-clearing behaviour.

## Related

- Closes #1778
