### PR TITLE
fix(rateLimit): log rate limit rejections

### DIFF
--- a/config/rateLimit/rateLimiter.js
+++ b/config/rateLimit/rateLimiter.js
@@ -49,6 +49,53 @@ const isTestOrDev = () =>
   process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
 
 /**
+ * Builds the `handler` that express-rate-limit invokes when a limit is exceeded.
+ *
+ * Without this, rejections are invisible in the logs. `generalRateLimit`,
+ * `deleteRateLimit` and `authRateLimit` all run *before* `responseTimeLogger`
+ * and `requestLogger` in the middleware order (see config/http.js), and the
+ * library's default handler responds without calling `next()`. Neither the
+ * `Req ::` nor the `Res ::` line is ever emitted, so a 429 leaves no trace
+ * beyond Azure's own HTTP logs — which carry no trace ID to correlate with.
+ *
+ * Overriding `handler` replaces the default responder entirely, so this must
+ * also send the response itself.
+ *
+ * `options.limit` is NOT the effective limit: it holds the `max` function
+ * unresolved, because `options` is computed once when the limiter is created.
+ * The resolved per-request numbers live on `req.rateLimit`.
+ *
+ * sails.log is patched by api/utils/logger.js to prefix the trace ID, and
+ * `traceId` runs first in the middleware order, so these lines correlate with
+ * the X-Trace-Id header the client received.
+ */
+const limitExceededHandler = (limiterName) => (req, res, next, options) => {
+  // Guarded: a throw here would turn the 429 into a 500 and let the request
+  // through unlabelled. Tests exercise these limiters on a bare express app
+  // where the sails global may be absent.
+  if (typeof sails !== 'undefined' && sails.log && sails.log.warn) {
+    sails.log.warn(
+      'Rate limit exceeded:',
+      JSON.stringify({
+        limiter: limiterName,
+        ip: req.ip,
+        method: req.method,
+        path: req.path,
+        userId: req.token ? req.token.id : undefined,
+        nickname: req.token ? req.token.nickname : undefined,
+        limit: req.rateLimit ? req.rateLimit.limit : undefined,
+        used: req.rateLimit ? req.rateLimit.used : undefined,
+        windowMs: options.windowMs,
+      })
+    );
+  }
+
+  // Mirrors the library's default handler.
+  res.status(options.statusCode);
+  if (!res.writableEnded) res.send(options.message);
+};
+
+/**
  * Returns the general rate limit for a request based on the caller's role.
  * Unauthenticated visitors get the lowest cap; higher roles get progressively
  * more headroom. Administrators are skipped entirely (see `skip`).
@@ -135,6 +182,7 @@ module.exports = {
     standardHeaders: true,
     statusCode: 429,
     validate: { keyGeneratorIpFallback: false },
+    handler: limitExceededHandler('general'),
     skip: (req) => {
       if (req.method.toUpperCase() === 'OPTIONS') return true;
       if (isTestOrDev()) return true;
@@ -159,6 +207,7 @@ module.exports = {
     standardHeaders: true,
     statusCode: 429,
     validate: { keyGeneratorIpFallback: false },
+    handler: limitExceededHandler('delete'),
     skip: (req) => {
       if (req.method.toUpperCase() !== 'DELETE') return true;
       if (isTestOrDev()) return true;
@@ -211,6 +260,7 @@ module.exports = {
     standardHeaders: true,
     statusCode: 429,
     validate: { keyGeneratorIpFallback: false },
+    handler: limitExceededHandler('auth'),
     skip: () => isTestOrDev(),
   }),
 
@@ -234,6 +284,7 @@ module.exports = {
     statusCode: 429,
     keyGenerator: (req) => `admin:${req.ip || 'unknown'}`,
     validate: { keyGeneratorIpFallback: false },
+    handler: limitExceededHandler('adminAuth'),
     skip: () => isTestOrDev(),
   }),
 };

--- a/test/integration/2_utils/rateLimiter.test.js
+++ b/test/integration/2_utils/rateLimiter.test.js
@@ -64,6 +64,7 @@ describe('Rate Limiter', () => {
 
   describe('in production environment', () => {
     let sailsBackup;
+    let warnLogs = [];
 
     before(() => {
       sailsBackup = global.sails;
@@ -82,10 +83,158 @@ describe('Rate Limiter', () => {
       process.env.USER_DELETE_RATE_LIMIT = TEST_USER_DELETE_LIMIT;
 
       // Mock the sails global used by deleteRateLimit.skip for origin checks
+      // and by the limit-exceeded handler for logging.
+      warnLogs = [];
       global.sails = {
         config: { custom: { baseUrl: 'http://localhost:1337' } },
-        log: { error: () => {}, info: () => {} },
+        log: {
+          error: () => {},
+          info: () => {},
+          warn: (...args) => warnLogs.push(args.join(' ')),
+        },
       };
+    });
+
+    // Parses the JSON payload out of the 'Rate limit exceeded:' log lines.
+    const exceededLogs = () =>
+      warnLogs
+        .filter((l) => l.startsWith('Rate limit exceeded:'))
+        .map((l) => JSON.parse(l.slice(l.indexOf('{'))));
+
+    describe('rate limit rejection logging', () => {
+      it('should log a warning naming the limiter, IP, method and path', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/api/v1/caves/1', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 2; i += 1) {
+          await agent.get('/api/v1/caves/1');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        should(logs[0].limiter).be.exactly('general');
+        should(logs[0].method).be.exactly('GET');
+        should(logs[0].path).be.exactly('/api/v1/caves/1');
+        should(logs[0].ip).be.a.String();
+        should(logs[0].windowMs).be.a.Number();
+      });
+
+      it('should log the resolved numeric limit, not the max function', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 2; i += 1) {
+          await agent.get('/test');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        // options.limit holds the unresolved `max` function; the effective
+        // limit must be read from req.rateLimit instead.
+        should(logs[0].limit).be.exactly(TEST_VISITOR_LIMIT);
+        should(logs[0].used).be.above(TEST_VISITOR_LIMIT);
+      });
+
+      it('should include the authenticated user in the log', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use((req, res, next) => {
+          req.token = { groups: [], nickname: 'User', id: 10 };
+          next();
+        });
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_USER_LIMIT + 2; i += 1) {
+          await agent.get('/test');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        should(logs[0].userId).be.exactly(10);
+        should(logs[0].nickname).be.exactly('User');
+      });
+
+      it('should name the delete limiter on DELETE rejections', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.deleteRateLimit);
+        app.delete('/api/v1/entrances/42', (req, res) =>
+          res.status(200).send('ok')
+        );
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_USER_DELETE_LIMIT + 3; i += 1) {
+          await agent.delete('/api/v1/entrances/42');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        should(logs[0].limiter).be.exactly('delete');
+        should(logs[0].method).be.exactly('DELETE');
+      });
+
+      it('should still return 429 with the configured message body', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        let limited;
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 2; i += 1) {
+          const res = await agent.get('/test');
+          if (res.status === 429) limited = res;
+        }
+
+        // Overriding `handler` replaces the library's default responder, so the
+        // status, message body and RateLimit headers must survive.
+        should(limited).be.ok();
+        should(limited.text).be.exactly(
+          'Too many requests with the same IP, try again later.'
+        );
+        should(limited.headers).have.property('retry-after');
+      });
+
+      it('should not log anything while under the limit', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_VISITOR_LIMIT - 2; i += 1) {
+          await agent.get('/test').expect(200);
+        }
+
+        should(exceededLogs()).be.empty();
+      });
+
+      it('should reject with 429 even when the sails global is absent', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.generalRateLimit);
+        app.get('/test', (req, res) => res.status(200).send('ok'));
+
+        // A throw inside the handler would surface as a 500 and lose the 429.
+        delete global.sails;
+        const agent = supertest.agent(app);
+        const responses = [];
+        for (let i = 0; i < TEST_VISITOR_LIMIT + 2; i += 1) {
+          const res = await agent.get('/test');
+          responses.push(res.status);
+        }
+
+        should(responses.filter((s) => s === 429).length).be.above(0);
+        should(responses.filter((s) => s === 500)).be.empty();
+      });
     });
 
     describe('generalRateLimit', () => {

--- a/test/integration/2_utils/rateLimiter.test.js
+++ b/test/integration/2_utils/rateLimiter.test.js
@@ -9,6 +9,8 @@ const TEST_USER_LIMIT = 20;
 const TEST_MODERATOR_LIMIT = 40;
 const TEST_DELETE_LIMIT = 5;
 const TEST_USER_DELETE_LIMIT = 1;
+const TEST_AUTH_LIMIT = 3;
+const TEST_ADMIN_AUTH_LIMIT = 2;
 
 const freshRateLimiter = () => {
   delete require.cache[
@@ -30,6 +32,8 @@ describe('Rate Limiter', () => {
       'MODERATOR_RATE_LIMIT',
       'DELETE_RATE_LIMIT',
       'USER_DELETE_RATE_LIMIT',
+      'AUTH_RATE_LIMIT',
+      'ADMIN_AUTH_RATE_LIMIT',
     ].forEach((key) => {
       envBackup[key] = process.env[key];
     });
@@ -81,6 +85,8 @@ describe('Rate Limiter', () => {
       process.env.MODERATOR_RATE_LIMIT = TEST_MODERATOR_LIMIT;
       process.env.DELETE_RATE_LIMIT = TEST_DELETE_LIMIT;
       process.env.USER_DELETE_RATE_LIMIT = TEST_USER_DELETE_LIMIT;
+      process.env.AUTH_RATE_LIMIT = TEST_AUTH_LIMIT;
+      process.env.ADMIN_AUTH_RATE_LIMIT = TEST_ADMIN_AUTH_LIMIT;
 
       // Mock the sails global used by deleteRateLimit.skip for origin checks
       // and by the limit-exceeded handler for logging.
@@ -234,6 +240,38 @@ describe('Rate Limiter', () => {
 
         should(responses.filter((s) => s === 429).length).be.above(0);
         should(responses.filter((s) => s === 500)).be.empty();
+      });
+
+      it('should name the auth limiter on authRateLimit rejections', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.authRateLimit);
+        app.post('/api/v1/login', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_AUTH_LIMIT + 2; i += 1) {
+          await agent.post('/api/v1/login');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        should(logs[0].limiter).be.exactly('auth');
+      });
+
+      it('should name the adminAuth limiter on adminAuthRateLimit rejections', async () => {
+        const rateLimiter = freshRateLimiter();
+        const app = express();
+        app.use(rateLimiter.adminAuthRateLimit);
+        app.post('/api/v1/login', (req, res) => res.status(200).send('ok'));
+
+        const agent = supertest.agent(app);
+        for (let i = 0; i < TEST_ADMIN_AUTH_LIMIT + 2; i += 1) {
+          await agent.post('/api/v1/login');
+        }
+
+        const logs = exceededLogs();
+        should(logs.length).be.above(0);
+        should(logs[0].limiter).be.exactly('adminAuth');
       });
     });
 


### PR DESCRIPTION
## 🤔 What

Rate limit rejections now leave a log line. Previously a `429` was invisible in application logs.

- Adds a shared `handler` to all four limiters in `config/rateLimit/rateLimiter.js` (`general`, `delete`, `auth`, `adminAuth`)
- Logs limiter name, IP, method, path, authenticated user, effective limit, hit count and window
- Adds 7 tests covering log contents and response integrity

## 🤷‍♂️ Why

- **A rejected request left no trace.** `generalRateLimit`, `deleteRateLimit` and `authRateLimit` all run *before* `responseTimeLogger` and `requestLogger` in the middleware order, and `express-rate-limit`'s default handler responds without calling `next()`. Neither the `Req ::` nor the `Res ::` line was ever emitted — so there was no way to tell from application logs that a client had been limited, let alone which limiter fired or against which IP.
- **This is a live blind spot, not a hypothetical one.** Verified against production: App Insights recorded **63 × `429`** in the last 30 days, all within the last day — `GET /api/v1/geoloc/entrances` across 4 paths from a single client walking map tiles. The application log for that day contains **1478 `Res ::` lines, none of them `429`**. The burst App Insights captured at 16:37:50 produced **zero** application log lines; the next entry is a health check 8 seconds later.
- **Brute-force attempts were unobservable.** `authRateLimit` and `adminAuthRateLimit` protect login and password-reset. Those are the rejections most worth seeing, and they were silent.
- **There was no other source for the client IP.** Azure is not a usable fallback here:
  - There are **no W3C HTTP logs** on this App Service. `httpLogs.fileSystem` reports `enabled: true`, but `LogFiles/http/` returns 404 — that directory is Windows-only. On Linux the only file log is the application's own stdout.
  - **App Insights anonymizes the client IP.** `client_IP` is `0.0.0.0` on **all 1483 requests** in the window, not only the rejected ones. Only geo-derived `client_City` / `client_CountryOrRegion` survive, and those cannot distinguish several clients behind one regional egress.

  So before this change a rate-limited client's IP was unavailable from any source. The `ip` field in the new log line is the only place it becomes visible.
- Only `adminAuthRateLimit` was incidentally visible, because it sits after the loggers in the chain.

## 🔍 How

`limitExceededHandler(limiterName)` is a factory returning an `express-rate-limit` `handler`, attached to each limiter. Two details drove the implementation, both verified at runtime rather than assumed:

- **`options.limit` is not the effective limit.** It holds the `max` function unresolved, because `options` is computed once when the limiter is created. The resolved per-request values live on `req.rateLimit` (`{limit, used, remaining, resetTime, key}`). Logging `options.limit` would have written a function into the log line — a test pins this.
- **Overriding `handler` replaces the library's default responder entirely**, so the handler must send the response itself. The `429` status, message body, `RateLimit-*` and `Retry-After` headers are all preserved.

The `sails` global is guarded: a throw inside the handler would convert the `429` into a `500` and let the caller past the limit. Verified with the global absent.

Log lines are prefixed with the trace ID (`sails.log` is patched by `api/utils/logger.js`, and `traceId` runs first in the middleware order), so they correlate with the `X-Trace-Id` header the client received.

The middleware `order` in `config/http.js` is untouched — moving the loggers above the limiters would have produced `Res :: … 429` lines but no IP or limiter name.

Sample output:

```
[<traceId>] Rate limit exceeded: {"limiter":"auth","ip":"…","method":"POST",
"path":"/api/v1/login","userId":42,"nickname":"Bob","limit":10,"used":11,"windowMs":900000}
```

The `ip` value carries the port suffix Azure forwards (`<addr>:<port>`), confirmed in production logs — this is the behaviour the existing `keyGenerator` comment documents.

## 🧪 Testing

Rate limiting is disabled in `test` and `development` (`isTestOrDev`), so the tests set `NODE_ENV=production` and exercise the limiters on a bare express app, as the existing suite already did.

```shell
npm run test -- --grep "Rate Limiter"
```

- Targeted `rateLimiter.test.js`: **23 passing** (was 16)
- `admin-rate-limit.test.js`: **4 passing**
- Full suite: **3322 passing, 0 failing**
- `npm run lint`: clean

New tests cover: field contents; the resolved-numeric-limit trap; authenticated user attribution; delete-limiter naming; response status/body/headers surviving the handler override; silence while under the limit; and `429` still returned when the `sails` global is absent.

## 📸 Previews

n/a — log output only, sample shown above.