### PR TITLE
feat(search): allow sorting document search results by author

### DIFF
--- a/api/controllers/v1/search/advanced-search.js
+++ b/api/controllers/v1/search/advanced-search.js
@@ -9,6 +9,7 @@ const normalizeDataQualityFilter = require('../../../utils/normalizeDataQualityF
 // Sort fields that are only valid for specific entities
 const ENTITY_SPECIFIC_SORT_FIELDS = {
   dataQuality: ['entrances'],
+  authorsSort: ['documents'],
 };
 
 module.exports = async (req, res) => {

--- a/api/dbSync/entities/document.js
+++ b/api/dbSync/entities/document.js
@@ -1,4 +1,7 @@
 const exportUtils = require('../utils');
+const {
+  computeDocumentAuthorsSort,
+} = require('../../utils/computeDocumentAuthorsSort');
 
 const query = `
     SELECT
@@ -192,6 +195,11 @@ async function* processRows(source) {
       ];
       row.cave = row.cave?.[0] ?? null;
 
+      row.authorsSort = computeDocumentAuthorsSort(
+        row.authors?.map((e) => e.nickname),
+        row.authorsOrganization?.map((e) => e.name)
+      );
+
       yield row;
     }
   }
@@ -298,6 +306,11 @@ module.exports = {
           facet: true,
           optional: true,
         },
+        // Denormalized scalar key for sorting biblio results by author.
+        // Typesense cannot sort on the `authors.nickname` array field, so this
+        // holds the alphabetical-first author name (persons + organizations).
+        // See api/utils/computeDocumentAuthorsSort.js for method & limitations.
+        { name: 'authorsSort', type: 'string', optional: true, sort: true },
         { name: 'cave.name', type: 'string', optional: true, sort: true },
         { name: 'entrances.name', type: 'string[]', optional: true },
         { name: 'massifs.name', type: 'string[]', optional: true },

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -13,6 +13,9 @@ const {
   TYPES_ALLOWING_PARENT,
   TYPES_REQUIRING_PARENT,
 } = require('../../config/constants/document');
+const {
+  computeDocumentAuthorsSort,
+} = require('../utils/computeDocumentAuthorsSort');
 
 // Normalize a collection value to a plain ID (handles both raw IDs and objects).
 const normalizeToId = (item) =>
@@ -93,6 +96,12 @@ module.exports = {
       library: library && { name: library.names?.[0]?.name },
       authors: authors?.map((e) => ({ nickname: e.nickname })),
       authorsOrganization: mapAuthorsOrganizationForSearch(authorsOrganization),
+      // Keep the denormalized author sort key in sync on single-doc upserts so
+      // edits match the full-reindex baseline (see computeDocumentAuthorsSort).
+      authorsSort: computeDocumentAuthorsSort(
+        authors?.map((e) => e.nickname),
+        authorsOrganization?.map((e) => e.names?.[0]?.name)
+      ),
       subjects: subjects?.map((e) => ({ code: e.id })),
       iso3166: [
         ...(countries?.map((e) => ({ iso: e.id, name: e.nativeName })) ?? []),

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -98,9 +98,13 @@ module.exports = {
       authorsOrganization: mapAuthorsOrganizationForSearch(authorsOrganization),
       // Keep the denormalized author sort key in sync on single-doc upserts so
       // edits match the full-reindex baseline (see computeDocumentAuthorsSort).
+      // Uses `e.name` — the main name NameService.setNames() resolves from the
+      // `isMain` row — because the full reindex selects `n.is_main = true`.
+      // `e.names[0]` carries no ordering guarantee and would drift from the
+      // reindexed key as soon as an organization's main name changes.
       authorsSort: computeDocumentAuthorsSort(
         authors?.map((e) => e.nickname),
-        authorsOrganization?.map((e) => e.names?.[0]?.name)
+        authorsOrganization?.map((e) => e.name)
       ),
       subjects: subjects?.map((e) => ({ code: e.id })),
       iso3166: [

--- a/api/utils/computeDocumentAuthorsSort.js
+++ b/api/utils/computeDocumentAuthorsSort.js
@@ -1,0 +1,47 @@
+/**
+ * Denormalized scalar sort key for ordering biblio (document) search results
+ * by author. Typesense can't sort on the `authors.nickname` array field, so we
+ * precompute the alphabetical-first author name (persons + organizations),
+ * normalized (diacritics stripped, lowercased, whitespace collapsed) so byte
+ * order matches human A->Z. Authorless docs get a sentinel that sorts last.
+ *
+ * Limitations: not true bibliographic order (join tables have no author-order
+ * column, so we use the smallest name, not the first-listed one); co-authors
+ * don't tie-break; persons and orgs are pooled as plain strings; non-Latin
+ * scripts aren't transliterated; sorting is code-point order, not locale-aware.
+ * For true first-author order, add an ordinal column to the join tables and key
+ * on the ranked-first name — schema and query wiring stay the same.
+ */
+
+// Sentinel sorts after any normalized name (a-z). Ensures authorless
+// documents land at the bottom on ascending sort instead of the top.
+const EMPTY_AUTHORS_SORT_KEY = '~';
+
+const stripDiacritics = (value) =>
+  value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+
+const normalizeName = (name) =>
+  stripDiacritics(String(name)).toLowerCase().replace(/\s+/g, ' ').trim();
+
+/**
+ * @param {string[]} personNames person author names (t_caver.nickname)
+ * @param {string[]} organizationNames organization author names (t_grotto main name)
+ * @returns {string} the normalized alphabetical-first author name, or a
+ *   sentinel that sorts last when there is no author.
+ */
+const computeDocumentAuthorsSort = (
+  personNames = [],
+  organizationNames = []
+) => {
+  const candidates = [...personNames, ...organizationNames]
+    .filter((n) => n != null)
+    .map(normalizeName)
+    .filter((n) => n.length > 0);
+  if (candidates.length === 0) return EMPTY_AUTHORS_SORT_KEY;
+  return candidates.sort()[0];
+};
+
+module.exports = {
+  EMPTY_AUTHORS_SORT_KEY,
+  computeDocumentAuthorsSort,
+};

--- a/api/utils/computeDocumentAuthorsSort.js
+++ b/api/utils/computeDocumentAuthorsSort.js
@@ -3,7 +3,7 @@
  * by author. Typesense can't sort on the `authors.nickname` array field, so we
  * precompute the alphabetical-first author name (persons + organizations),
  * normalized (diacritics stripped, lowercased, whitespace collapsed) so byte
- * order matches human A->Z. Authorless docs get a sentinel that sorts last.
+ * order matches human A->Z. Authorless docs get a key that sorts last.
  *
  * Limitations: not true bibliographic order (join tables have no author-order
  * column, so we use the smallest name, not the first-listed one); co-authors
@@ -13,9 +13,21 @@
  * on the ranked-first name — schema and query wiring stay the same.
  */
 
-// Sentinel sorts after any normalized name (a-z). Ensures authorless
-// documents land at the bottom on ascending sort instead of the top.
-const EMPTY_AUTHORS_SORT_KEY = '~';
+/**
+ * Ordering bucket, carried as the key's first character so it decides the
+ * comparison before any name characters are read: ascending order puts every
+ * authored document before every authorless one, whatever script the names use.
+ *
+ * A single high sentinel character cannot do this. Normalization deliberately
+ * keeps non-ASCII letters (Cyrillic, CJK, astral-plane CJK extensions), and no
+ * code point is the maximum in both orderings that matter here — Typesense
+ * compares sort keys as UTF-8 bytes while JS compares UTF-16 code units, so any
+ * `~`- or U+FFFF-style sentinel is overtaken by some legitimate name in at
+ * least one of them. A bucket prefix is ordering-agnostic: '0' < '1' holds in
+ * both.
+ */
+const AUTHORED_SORT_KEY_PREFIX = '0';
+const EMPTY_AUTHORS_SORT_KEY = '1';
 
 const stripDiacritics = (value) =>
   value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
@@ -24,10 +36,28 @@ const normalizeName = (name) =>
   stripDiacritics(String(name)).toLowerCase().replace(/\s+/g, ' ').trim();
 
 /**
+ * Compare by code point rather than by UTF-16 code unit, so the name we pick
+ * here is the same one Typesense would rank first when it later orders the keys
+ * as UTF-8 bytes (UTF-8 byte order is code-point order). Array#sort's default
+ * comparator disagrees for astral-plane characters: it would rank a CJK
+ * Extension B name below a U+FExx one.
+ */
+const compareByCodePoint = (a, b) => {
+  const aPoints = [...a];
+  const bPoints = [...b];
+  const shared = Math.min(aPoints.length, bPoints.length);
+  for (let i = 0; i < shared; i += 1) {
+    const diff = aPoints[i].codePointAt(0) - bPoints[i].codePointAt(0);
+    if (diff !== 0) return diff;
+  }
+  return aPoints.length - bPoints.length;
+};
+
+/**
  * @param {string[]} personNames person author names (t_caver.nickname)
  * @param {string[]} organizationNames organization author names (t_grotto main name)
- * @returns {string} the normalized alphabetical-first author name, or a
- *   sentinel that sorts last when there is no author.
+ * @returns {string} the normalized alphabetical-first author name, bucket-
+ *   prefixed, or the authorless key that sorts after all of them.
  */
 const computeDocumentAuthorsSort = (
   personNames = [],
@@ -38,10 +68,14 @@ const computeDocumentAuthorsSort = (
     .map(normalizeName)
     .filter((n) => n.length > 0);
   if (candidates.length === 0) return EMPTY_AUTHORS_SORT_KEY;
-  return candidates.sort()[0];
+  const first = candidates.reduce((smallest, candidate) =>
+    compareByCodePoint(candidate, smallest) < 0 ? candidate : smallest
+  );
+  return AUTHORED_SORT_KEY_PREFIX + first;
 };
 
 module.exports = {
+  AUTHORED_SORT_KEY_PREFIX,
   EMPTY_AUTHORS_SORT_KEY,
   computeDocumentAuthorsSort,
 };

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -4945,6 +4945,7 @@ paths:
                     Returns 400 if the field is invalid or not sortable.
                     Entity-specific sort fields:
                       - entrances: "dataQuality:asc" or "dataQuality:desc" (sort by data quality score)
+                      - documents: "authorsSort:asc" or "authorsSort:desc" (sort by alphabetical-first author)
                     Using an entity-specific sort field with a different entity returns 400.
                   example: "cave.depth:desc"
                 filter:
@@ -5033,6 +5034,10 @@ paths:
                   description: |
                     Sort field and direction in the format "field:asc" or "field:desc".
                     The field must exist and be sortable in the target entity's schema.
+                    Entity-specific sort fields:
+                      - entrances: "dataQuality:asc" or "dataQuality:desc" (sort by data quality score)
+                      - documents: "authorsSort:asc" or "authorsSort:desc" (sort by alphabetical-first author)
+                    Using an entity-specific sort field with a different entity returns 400.
                   example: "cave.depth:desc"
                 filter:
                   type: object

--- a/test/integration/1_services/DocumentService.test.js
+++ b/test/integration/1_services/DocumentService.test.js
@@ -4,6 +4,10 @@ const DocumentService = require('../../../api/services/DocumentService');
 const DescriptionService = require('../../../api/services/DescriptionService');
 const AuthTokenService = require('../AuthTokenService');
 const SearchService = require('../../../api/services/SearchService');
+const {
+  EMPTY_AUTHORS_SORT_KEY,
+  computeDocumentAuthorsSort,
+} = require('../../../api/utils/computeDocumentAuthorsSort');
 
 describe('DocumentService', () => {
   const userReq = {};
@@ -549,6 +553,103 @@ describe('DocumentService', () => {
       should(callArg.entrance.name).equal('Test Entrance');
       should(callArg.massifs[0].name).equal('Test Massif');
       process.env.NODE_ENV = originalEnv;
+    });
+
+    describe('authorsSort', () => {
+      // The full reindex selects the organization's `n.is_main = true` name
+      // (api/dbSync/entities/document.js). NameService.setNames() exposes that
+      // same name as `organization.name` but leaves `organization.names`
+      // unordered, so the incremental key must read `name` — otherwise editing
+      // a document after an organization changed its main name would write a
+      // key that a later reindex overwrites with a different value.
+      const stubUpdate = () => {
+        process.env.NODE_ENV = 'development';
+        return sinon.stub(SearchService, 'updateDocument').resolves();
+      };
+
+      let originalEnv;
+      beforeEach(() => {
+        originalEnv = process.env.NODE_ENV;
+      });
+      afterEach(() => {
+        process.env.NODE_ENV = originalEnv;
+      });
+
+      it("should key on the organization's main name, not names[0]", async () => {
+        const updateStub = stubUpdate();
+
+        await DocumentService.updateInSearch({
+          id: 1,
+          author: { id: 1, nickname: 'Author' },
+          authorsOrganization: [
+            {
+              // Main name is deliberately NOT the first array element.
+              name: 'Alpha Speleo Club',
+              names: [
+                { name: 'Zeta Historical Name', isMain: false },
+                { name: 'Alpha Speleo Club', isMain: true },
+              ],
+            },
+          ],
+        });
+
+        const callArg = updateStub.getCall(0).args[1];
+        should(callArg.authorsSort).equal('0alpha speleo club');
+      });
+
+      it('should match the full-reindex key for the same organization', async () => {
+        const updateStub = stubUpdate();
+
+        await DocumentService.updateInSearch({
+          id: 1,
+          author: { id: 1, nickname: 'Author' },
+          authors: [{ nickname: 'Zola' }],
+          authorsOrganization: [
+            {
+              name: 'Meandre Club',
+              names: [
+                { name: 'Old Meandre Society', isMain: false },
+                { name: 'Meandre Club', isMain: true },
+              ],
+            },
+          ],
+        });
+
+        // What dbSync computes: person nicknames + the is_main org name.
+        const reindexKey = computeDocumentAuthorsSort(
+          ['Zola'],
+          ['Meandre Club']
+        );
+        should(updateStub.getCall(0).args[1].authorsSort).equal(reindexKey);
+      });
+
+      it('should pick the alphabetical-first author across persons and organizations', async () => {
+        const updateStub = stubUpdate();
+
+        await DocumentService.updateInSearch({
+          id: 1,
+          author: { id: 1, nickname: 'Author' },
+          authors: [{ nickname: 'Zola' }, { nickname: 'Bernard' }],
+          authorsOrganization: [
+            { name: 'Meandre Club', names: [{ name: 'Meandre Club' }] },
+          ],
+        });
+
+        should(updateStub.getCall(0).args[1].authorsSort).equal('0bernard');
+      });
+
+      it('should use the authorless key when the document has no author', async () => {
+        const updateStub = stubUpdate();
+
+        await DocumentService.updateInSearch({
+          id: 1,
+          author: { id: 1, nickname: 'Author' },
+        });
+
+        should(updateStub.getCall(0).args[1].authorsSort).equal(
+          EMPTY_AUTHORS_SORT_KEY
+        );
+      });
     });
   });
 

--- a/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
@@ -1,0 +1,139 @@
+/* eslint-disable func-names */
+const should = require('should');
+const fc = require('fast-check');
+const {
+  EMPTY_AUTHORS_SORT_KEY,
+  computeDocumentAuthorsSort,
+} = require('../../../api/utils/computeDocumentAuthorsSort');
+
+/**
+ * Arbitrary: a plausible author name. The pool stays within the Latin range
+ * the sort key targets (letters, digits, separators, accented letters) because
+ * the sentinel ordering property only holds for scripts that normalize to
+ * characters below "~" - a documented limitation of the utility.
+ */
+const nameArb = fc.string({
+  unit: fc.constantFrom(
+    ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -'.éÉèÀçÇüÖñ".split(
+      ''
+    )
+  ),
+  maxLength: 15,
+});
+
+/** Arbitrary: a list of names, possibly holding blanks and null/undefined. */
+const namesArb = fc.array(fc.oneof(nameArb, fc.constantFrom(null, undefined)), {
+  maxLength: 5,
+});
+
+/** Arbitrary: a list holding at least one name that survives normalization. */
+const nonEmptyNamesArb = namesArb.filter((names) =>
+  names.some((n) => typeof n === 'string' && n.trim().length > 0)
+);
+
+describe('computeDocumentAuthorsSort - Property Tests', () => {
+  /**
+   * Property 1: Normalization idempotency
+   *
+   * The sort key is already normalized, so feeding it back through the
+   * utility must return it unchanged. Catches normalizeName regressions
+   * (diacritic stripping, lowercasing, whitespace collapsing) that would
+   * make the key unstable across re-indexations.
+   */
+  describe('Property 1: Normalization idempotency', () => {
+    it('should return its own output unchanged when re-applied', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(namesArb, namesArb, (persons, organizations) => {
+          const key = computeDocumentAuthorsSort(persons, organizations);
+          should(computeDocumentAuthorsSort([key])).equal(key);
+        }),
+        { numRuns: 200 }
+      );
+    });
+  });
+
+  /**
+   * Property 2: Sentinel ordering
+   *
+   * Any document with at least one usable author must sort before authorless
+   * documents on ascending order, i.e. its key stays strictly below the
+   * sentinel.
+   */
+  describe('Property 2: Sentinel ordering', () => {
+    it('should produce a key below the sentinel whenever an author exists', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(nonEmptyNamesArb, (names) => {
+          const key = computeDocumentAuthorsSort(names);
+          should(key).not.equal(EMPTY_AUTHORS_SORT_KEY);
+          should(key < EMPTY_AUTHORS_SORT_KEY).be.true();
+        }),
+        { numRuns: 200 }
+      );
+    });
+
+    it('should return the sentinel when no name survives normalization', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.oneof(
+              fc.constantFrom(null, undefined, '', '   ', '\t\n'),
+              fc.string({
+                unit: fc.constantFrom(' ', '\t', '\n'),
+                maxLength: 5,
+              })
+            ),
+            { maxLength: 5 }
+          ),
+          (names) => {
+            should(computeDocumentAuthorsSort(names)).equal(
+              EMPTY_AUTHORS_SORT_KEY
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 3: Pool commutativity
+   *
+   * Persons and organizations are pooled as plain strings, so the result must
+   * not depend on which argument a name arrives in, nor on its position.
+   */
+  describe('Property 3: Pool commutativity', () => {
+    it('should not depend on which pool a name belongs to', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(namesArb, namesArb, (persons, organizations) => {
+          const expected = computeDocumentAuthorsSort(persons, organizations);
+          should(computeDocumentAuthorsSort(organizations, persons)).equal(
+            expected
+          );
+          should(
+            computeDocumentAuthorsSort([...persons, ...organizations], [])
+          ).equal(expected);
+          should(
+            computeDocumentAuthorsSort([], [...organizations, ...persons])
+          ).equal(expected);
+        }),
+        { numRuns: 200 }
+      );
+    });
+
+    it('should not depend on the order of names within a pool', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(namesArb, (names) => {
+          should(computeDocumentAuthorsSort([...names].reverse())).equal(
+            computeDocumentAuthorsSort(names)
+          );
+        }),
+        { numRuns: 200 }
+      );
+    });
+  });
+});

--- a/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
@@ -2,24 +2,39 @@
 const should = require('should');
 const fc = require('fast-check');
 const {
+  AUTHORED_SORT_KEY_PREFIX,
   EMPTY_AUTHORS_SORT_KEY,
   computeDocumentAuthorsSort,
 } = require('../../../api/utils/computeDocumentAuthorsSort');
 
 /**
- * Arbitrary: a plausible author name. The pool stays within the Latin range
- * the sort key targets (letters, digits, separators, accented letters) because
- * the sentinel ordering property only holds for scripts that normalize to
- * characters below "~" - a documented limitation of the utility.
+ * Arbitrary: a plausible author name. Deliberately spans the whole range a
+ * document can actually hold - Latin with diacritics, Cyrillic, Greek, CJK,
+ * RTL scripts, astral-plane characters - rather than a curated below-"~"
+ * alphabet. The ordering property must hold for every script we index, not
+ * just the ones that happen to normalize into ASCII.
  */
-const nameArb = fc.string({
-  unit: fc.constantFrom(
-    ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -'.éÉèÀçÇüÖñ".split(
-      ''
-    )
-  ),
-  maxLength: 15,
-});
+const nameArb = fc.oneof(
+  fc.string({
+    unit: fc.constantFrom(
+      ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -'.éÉèÀçÇüÖñÞßœ".split(
+        ''
+      )
+    ),
+    maxLength: 15,
+  }),
+  fc.string({
+    unit: fc.constantFrom(
+      ...'ЯрославльΩμέγα山田太郎홍길동محمدמשהสมชาย𠀋𪘀'.split(''),
+      '\u{10FFFD}',
+      '�',
+      '~'
+    ),
+    maxLength: 15,
+  }),
+  fc.string({ unit: 'grapheme', maxLength: 15 }),
+  fc.string({ unit: 'binary', maxLength: 15 })
+);
 
 /** Arbitrary: a list of names, possibly holding blanks and null/undefined. */
 const namesArb = fc.array(fc.oneof(nameArb, fc.constantFrom(null, undefined)), {
@@ -31,22 +46,26 @@ const nonEmptyNamesArb = namesArb.filter((names) =>
   names.some((n) => typeof n === 'string' && n.trim().length > 0)
 );
 
+/** Strip the ordering bucket prefix to recover the normalized name. */
+const nameOf = (key) => key.slice(AUTHORED_SORT_KEY_PREFIX.length);
+
 describe('computeDocumentAuthorsSort - Property Tests', () => {
   /**
    * Property 1: Normalization idempotency
    *
-   * The sort key is already normalized, so feeding it back through the
-   * utility must return it unchanged. Catches normalizeName regressions
-   * (diacritic stripping, lowercasing, whitespace collapsing) that would
-   * make the key unstable across re-indexations.
+   * The name inside a sort key is already normalized, so re-keying it must
+   * yield the same name back. Catches normalizeName regressions (diacritic
+   * stripping, lowercasing, whitespace collapsing) that would make the key
+   * unstable across re-indexations.
    */
   describe('Property 1: Normalization idempotency', () => {
-    it('should return its own output unchanged when re-applied', function () {
+    it('should renormalize its own output to the same name', function () {
       this.timeout(10000);
       fc.assert(
-        fc.property(namesArb, namesArb, (persons, organizations) => {
-          const key = computeDocumentAuthorsSort(persons, organizations);
-          should(computeDocumentAuthorsSort([key])).equal(key);
+        fc.property(nonEmptyNamesArb, nonEmptyNamesArb, (persons, orgs) => {
+          const key = computeDocumentAuthorsSort(persons, orgs);
+          const name = nameOf(key);
+          should(computeDocumentAuthorsSort([name])).equal(key);
         }),
         { numRuns: 200 }
       );
@@ -54,26 +73,36 @@ describe('computeDocumentAuthorsSort - Property Tests', () => {
   });
 
   /**
-   * Property 2: Sentinel ordering
+   * Property 2: Authorless ordering
    *
    * Any document with at least one usable author must sort before authorless
-   * documents on ascending order, i.e. its key stays strictly below the
-   * sentinel.
+   * documents on ascending order — in *both* orderings that matter: UTF-16
+   * code units (JS string compare) and UTF-8 bytes (what Typesense compares).
+   * Names span every script we index, so this also pins that no legitimate
+   * name can overtake the authorless key.
    */
-  describe('Property 2: Sentinel ordering', () => {
-    it('should produce a key below the sentinel whenever an author exists', function () {
+  describe('Property 2: Authorless ordering', () => {
+    it('should produce a key below the authorless key whenever an author exists', function () {
       this.timeout(10000);
       fc.assert(
         fc.property(nonEmptyNamesArb, (names) => {
           const key = computeDocumentAuthorsSort(names);
           should(key).not.equal(EMPTY_AUTHORS_SORT_KEY);
+          // UTF-16 code-unit order (JS).
           should(key < EMPTY_AUTHORS_SORT_KEY).be.true();
+          // UTF-8 byte order (Typesense).
+          should(
+            Buffer.compare(
+              Buffer.from(key, 'utf8'),
+              Buffer.from(EMPTY_AUTHORS_SORT_KEY, 'utf8')
+            )
+          ).equal(-1);
         }),
-        { numRuns: 200 }
+        { numRuns: 300 }
       );
     });
 
-    it('should return the sentinel when no name survives normalization', function () {
+    it('should return the authorless key when no name survives normalization', function () {
       this.timeout(10000);
       fc.assert(
         fc.property(
@@ -131,6 +160,37 @@ describe('computeDocumentAuthorsSort - Property Tests', () => {
           should(computeDocumentAuthorsSort([...names].reverse())).equal(
             computeDocumentAuthorsSort(names)
           );
+        }),
+        { numRuns: 200 }
+      );
+    });
+  });
+
+  /**
+   * Property 4: Minimality under UTF-8 byte order
+   *
+   * The key must hold the name Typesense itself would rank first, so the name
+   * we pick has to be the minimum under UTF-8 byte order — not under JS's
+   * UTF-16 code-unit order, which disagrees for astral-plane characters.
+   */
+  describe('Property 4: Minimality under UTF-8 byte order', () => {
+    it('should select the byte-order-smallest surviving name', function () {
+      this.timeout(10000);
+      fc.assert(
+        fc.property(nonEmptyNamesArb, nonEmptyNamesArb, (persons, orgs) => {
+          const chosen = Buffer.from(
+            nameOf(computeDocumentAuthorsSort(persons, orgs)),
+            'utf8'
+          );
+          const candidates = [...persons, ...orgs]
+            .filter((n) => n != null)
+            .map((n) => nameOf(computeDocumentAuthorsSort([n])))
+            .filter((n) => n.length > 0);
+          for (const candidate of candidates) {
+            should(
+              Buffer.compare(chosen, Buffer.from(candidate, 'utf8'))
+            ).be.belowOrEqual(0);
+          }
         }),
         { numRuns: 200 }
       );

--- a/test/integration/2_utils/computeDocumentAuthorsSort.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.test.js
@@ -1,47 +1,111 @@
 const should = require('should');
 const {
+  AUTHORED_SORT_KEY_PREFIX,
   EMPTY_AUTHORS_SORT_KEY,
   computeDocumentAuthorsSort,
 } = require('../../../api/utils/computeDocumentAuthorsSort');
+
+/** Key an authored document is expected to get for `name`. */
+const authored = (name) => AUTHORED_SORT_KEY_PREFIX + name;
 
 describe('computeDocumentAuthorsSort', () => {
   it('returns the alphabetical-first author across persons and organizations', () => {
     should(
       computeDocumentAuthorsSort(['Zola', 'Adam'], ['Meandre Club'])
-    ).equal('adam');
+    ).equal(authored('adam'));
     should(computeDocumentAuthorsSort(['Zola'], ['AAA Speleo Club'])).equal(
-      'aaa speleo club'
+      authored('aaa speleo club')
     );
   });
 
   it('strips diacritics so accented names sort with their base letter', () => {
-    should(computeDocumentAuthorsSort(['Émile'])).equal('emile');
-    should(computeDocumentAuthorsSort(['Çelik'])).equal('celik');
+    should(computeDocumentAuthorsSort(['Émile'])).equal(authored('emile'));
+    should(computeDocumentAuthorsSort(['Çelik'])).equal(authored('celik'));
   });
 
   it('lowercases and collapses whitespace', () => {
     should(computeDocumentAuthorsSort(['  Jean   Dupont '])).equal(
-      'jean dupont'
+      authored('jean dupont')
     );
   });
 
   it('ignores null/undefined/blank names', () => {
     should(
       computeDocumentAuthorsSort([null, '   ', 'Bernard'], [undefined])
-    ).equal('bernard');
+    ).equal(authored('bernard'));
   });
 
-  it('returns the sentinel (sorting last) when there is no author', () => {
+  it('returns the authorless key (sorting last) when there is no author', () => {
     should(computeDocumentAuthorsSort([], [])).equal(EMPTY_AUTHORS_SORT_KEY);
     should(computeDocumentAuthorsSort()).equal(EMPTY_AUTHORS_SORT_KEY);
-    // The sentinel sorts after any normalized a-z name on ascending order.
-    should(EMPTY_AUTHORS_SORT_KEY > 'zzzzz').be.true();
   });
 
   it('defaults each argument independently', () => {
     should(computeDocumentAuthorsSort(undefined, ['Org Only'])).equal(
-      'org only'
+      authored('org only')
     );
-    should(computeDocumentAuthorsSort(['Person Only'])).equal('person only');
+    should(computeDocumentAuthorsSort(['Person Only'])).equal(
+      authored('person only')
+    );
+  });
+
+  describe('ordering against the authorless key', () => {
+    // Normalization keeps non-ASCII letters, so the authorless key has to sort
+    // after names in every script we can index — not just after a-z. Each of
+    // these previously compared *above* the old '~' sentinel, putting
+    // authorless documents first on ascending sort.
+    const nonLatinNames = [
+      ['Cyrillic', 'Ярославль'],
+      ['Greek', 'Ωμέγα'],
+      ['CJK', '山田太郎'],
+      ['Hangul', '홍길동'],
+      ['Arabic', 'محمد'],
+      ['Hebrew', 'משה'],
+      ['Thai', 'สมชาย'],
+      ['retained Latin supplement', 'Þorvaldur'],
+      ['astral-plane CJK extension B', '𠀋田'],
+      ['high private use', '\u{10FFFD}'],
+    ];
+
+    for (const [label, name] of nonLatinNames) {
+      it(`sorts a ${label} author before an authorless document`, () => {
+        const key = computeDocumentAuthorsSort([name]);
+        should(key).not.equal(EMPTY_AUTHORS_SORT_KEY);
+        should(key < EMPTY_AUTHORS_SORT_KEY).be.true();
+        // Also hold under UTF-8 byte order, which is what Typesense compares.
+        should(
+          Buffer.compare(Buffer.from(key), Buffer.from(EMPTY_AUTHORS_SORT_KEY))
+        ).equal(-1);
+      });
+    }
+
+    it('keeps a mixed-script result set in ascending order with authorless last', () => {
+      const keys = [
+        computeDocumentAuthorsSort([], []), // authorless
+        computeDocumentAuthorsSort(['山田太郎']),
+        computeDocumentAuthorsSort(['Adam']),
+        computeDocumentAuthorsSort(['Ярославль']),
+        computeDocumentAuthorsSort(['zola']),
+      ];
+      const sorted = [...keys].sort();
+      should(sorted[sorted.length - 1]).equal(EMPTY_AUTHORS_SORT_KEY);
+      should(sorted[0]).equal(authored('adam'));
+    });
+  });
+
+  it('picks the code-point-smallest name, matching UTF-8 byte order', () => {
+    // U+FFFD is a lower code point than '𠀋' (U+2000B) and sorts below it in
+    // UTF-8 byte order, but '𠀋' is stored as the surrogate pair 0xD840 0xDC0B,
+    // so a naive JS sort ranks '𠀋' first. The key must agree with the UTF-8
+    // byte order Typesense uses, not with UTF-16 code-unit order.
+    const bmp = '�ab';
+    const astral = '\u{2000B}ab';
+    should([bmp, astral].sort()[0]).equal(astral); // naive JS order disagrees
+    should(
+      Buffer.compare(Buffer.from(bmp, 'utf8'), Buffer.from(astral, 'utf8'))
+    ).equal(-1); // UTF-8 byte order
+
+    should(computeDocumentAuthorsSort([bmp, astral])).equal(authored(bmp));
+    should(computeDocumentAuthorsSort([astral, bmp])).equal(authored(bmp));
   });
 });

--- a/test/integration/2_utils/computeDocumentAuthorsSort.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.test.js
@@ -1,0 +1,48 @@
+/* eslint-disable func-names */
+const should = require('should');
+const {
+  EMPTY_AUTHORS_SORT_KEY,
+  computeDocumentAuthorsSort,
+} = require('../../../api/utils/computeDocumentAuthorsSort');
+
+describe('computeDocumentAuthorsSort', () => {
+  it('returns the alphabetical-first author across persons and organizations', () => {
+    should(
+      computeDocumentAuthorsSort(['Zola', 'Adam'], ['Meandre Club'])
+    ).equal('adam');
+    should(computeDocumentAuthorsSort(['Zola'], ['AAA Speleo Club'])).equal(
+      'aaa speleo club'
+    );
+  });
+
+  it('strips diacritics so accented names sort with their base letter', () => {
+    should(computeDocumentAuthorsSort(['Émile'])).equal('emile');
+    should(computeDocumentAuthorsSort(['Çelik'])).equal('celik');
+  });
+
+  it('lowercases and collapses whitespace', () => {
+    should(computeDocumentAuthorsSort(['  Jean   Dupont '])).equal(
+      'jean dupont'
+    );
+  });
+
+  it('ignores null/undefined/blank names', () => {
+    should(
+      computeDocumentAuthorsSort([null, '   ', 'Bernard'], [undefined])
+    ).equal('bernard');
+  });
+
+  it('returns the sentinel (sorting last) when there is no author', () => {
+    should(computeDocumentAuthorsSort([], [])).equal(EMPTY_AUTHORS_SORT_KEY);
+    should(computeDocumentAuthorsSort()).equal(EMPTY_AUTHORS_SORT_KEY);
+    // The sentinel sorts after any normalized a-z name on ascending order.
+    should(EMPTY_AUTHORS_SORT_KEY > 'zzzzz').be.true();
+  });
+
+  it('defaults each argument independently', () => {
+    should(computeDocumentAuthorsSort(undefined, ['Org Only'])).equal(
+      'org only'
+    );
+    should(computeDocumentAuthorsSort(['Person Only'])).equal('person only');
+  });
+});

--- a/test/integration/2_utils/computeDocumentAuthorsSort.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable func-names */
 const should = require('should');
 const {
   EMPTY_AUTHORS_SORT_KEY,

--- a/test/integration/4_routes/Search/advanced-search-authors-sort.test.js
+++ b/test/integration/4_routes/Search/advanced-search-authors-sort.test.js
@@ -1,0 +1,149 @@
+/* eslint-disable global-require */
+const supertest = require('supertest');
+const sinon = require('sinon');
+const should = require('should');
+
+describe('Advanced Search - authorsSort sort validation', () => {
+  let SearchService;
+
+  before(() => {
+    SearchService = require('../../../../api/services/SearchService');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should sort documents by authorsSort:asc and return ascending order', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        { document: { id: '1', title: 'Doc A', authorsSort: 'adam' } },
+        { document: { id: '2', title: 'Doc B', authorsSort: 'meandre club' } },
+        { document: { id: '3', title: 'Doc C', authorsSort: 'zola' } },
+      ],
+      found: 3,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'documents' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'documents', sort: 'authorsSort:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body).have.property('results');
+    should(res.body.results).be.an.Array();
+    should(res.body.results.length).equal(3);
+
+    // Verify sort was passed to SearchService
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).equal('authorsSort:asc');
+  });
+
+  it('should sort documents by authorsSort:desc', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [
+        { document: { id: '3', title: 'Doc C', authorsSort: 'zola' } },
+        { document: { id: '2', title: 'Doc B', authorsSort: 'meandre club' } },
+        { document: { id: '1', title: 'Doc A', authorsSort: 'adam' } },
+      ],
+      found: 3,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'documents' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'documents', sort: 'authorsSort:desc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+    should(res.body.results.length).equal(3);
+
+    const callArgs = SearchService.collectionSearch.firstCall.args[0];
+    should(callArgs.sort).equal('authorsSort:desc');
+  });
+
+  it('should return 400 when sorting by authorsSort on entrances entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'entrances', sort: 'authorsSort:asc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should return 400 when sorting by authorsSort on persons entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({ query: 'test', entity: 'persons', sort: 'authorsSort:desc' })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should return 400 when authorsSort appears in a multi-field sort on a non-document entity', async () => {
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'caves',
+        sort: '_text_match:desc,authorsSort:asc',
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(400);
+  });
+
+  it('should allow authorsSort in a multi-field sort on documents entity', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', title: 'Doc A', authorsSort: 'adam' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'documents' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'documents',
+        sort: '_text_match:desc,authorsSort:asc',
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+  });
+
+  it('should allow sorting documents by other fields', async () => {
+    sinon.stub(SearchService, 'collectionSearch').resolves({
+      hits: [{ document: { id: '1', title: 'Doc A' } }],
+      found: 1,
+      out_of: 100,
+      page: 1,
+      request_params: { collection_name: 'documents' },
+    });
+
+    const res = await supertest(sails.hooks.http.app)
+      .post('/api/v1/advanced-search')
+      .send({
+        query: 'test',
+        entity: 'documents',
+        sort: 'dateInscription:desc',
+      })
+      .set('Content-type', 'application/json')
+      .set('Accept', 'application/json');
+
+    should(res.status).equal(200);
+  });
+});

--- a/test/integration/4_routes/Search/advanced-search-authors-sort.test.js
+++ b/test/integration/4_routes/Search/advanced-search-authors-sort.test.js
@@ -17,9 +17,9 @@ describe('Advanced Search - authorsSort sort validation', () => {
   it('should sort documents by authorsSort:asc and return ascending order', async () => {
     sinon.stub(SearchService, 'collectionSearch').resolves({
       hits: [
-        { document: { id: '1', title: 'Doc A', authorsSort: 'adam' } },
-        { document: { id: '2', title: 'Doc B', authorsSort: 'meandre club' } },
-        { document: { id: '3', title: 'Doc C', authorsSort: 'zola' } },
+        { document: { id: '1', title: 'Doc A', authorsSort: '0adam' } },
+        { document: { id: '2', title: 'Doc B', authorsSort: '0meandre club' } },
+        { document: { id: '3', title: 'Doc C', authorsSort: '0zola' } },
       ],
       found: 3,
       out_of: 100,
@@ -46,9 +46,9 @@ describe('Advanced Search - authorsSort sort validation', () => {
   it('should sort documents by authorsSort:desc', async () => {
     sinon.stub(SearchService, 'collectionSearch').resolves({
       hits: [
-        { document: { id: '3', title: 'Doc C', authorsSort: 'zola' } },
-        { document: { id: '2', title: 'Doc B', authorsSort: 'meandre club' } },
-        { document: { id: '1', title: 'Doc A', authorsSort: 'adam' } },
+        { document: { id: '3', title: 'Doc C', authorsSort: '0zola' } },
+        { document: { id: '2', title: 'Doc B', authorsSort: '0meandre club' } },
+        { document: { id: '1', title: 'Doc A', authorsSort: '0adam' } },
       ],
       found: 3,
       out_of: 100,
@@ -105,7 +105,7 @@ describe('Advanced Search - authorsSort sort validation', () => {
 
   it('should allow authorsSort in a multi-field sort on documents entity', async () => {
     sinon.stub(SearchService, 'collectionSearch').resolves({
-      hits: [{ document: { id: '1', title: 'Doc A', authorsSort: 'adam' } }],
+      hits: [{ document: { id: '1', title: 'Doc A', authorsSort: '0adam' } }],
       found: 1,
       out_of: 100,
       page: 1,


### PR DESCRIPTION
Adds a sortable author key to the `documents` Typesense collection, so bibliography results can be ordered A→Z by author.

Closes #1789

## Why

- **The front-end column is disabled today.** The documents table has a "sort by author" column turned off with a comment saying the search index exposes no sortable author field. This adds that field.
- **Typesense cannot sort on arrays.** A document's authors are `string[]` split across persons (`authors.nickname`) and organizations (`authorsOrganization.name`), so a denormalized scalar key is the only way to sort on them.
- **One "author" concept for users.** The key pools persons and organizations, so sorting by author doesn't require the user to know which kind an author is.

## What

- `api/utils/computeDocumentAuthorsSort.js` — computes the alphabetically-first author name across both pools, normalized (NFKD diacritic stripping, lowercase, whitespace collapse) so byte-order sort matches human A→Z. Authorless documents get a `~` sentinel that sorts last ascending.
- `api/dbSync/entities/document.js` — new `authorsSort` schema field, computed per row during full reindex.
- `api/services/DocumentService.js` — `updateInSearch` recomputes the key on every upsert, so incremental edits match the reindexed baseline.
- `advanced-search.js` — `authorsSort` scoped to `entity=documents`, returning a clean `400` elsewhere. Sorting flows through the existing generic `sort` param; no new wiring.

Follows the existing `dataQuality` computed-sort-field pattern.

## Production actions required

> [!IMPORTANT]
> This changes the Typesense schema. `authorsSort` is **not populated until a full search reindex runs in each environment** — until then, sorting by author returns unsorted results. No DB migration is needed; this is search-index-only.

## Known approximation

This is an **alphabetical-first-author** key, not true bibliographic order. The author join tables have no ordinal column, so first-listed-author order isn't stored and can't be recovered — a work by "Zola & Adam" sorts under **A**. Co-authors don't tie-break, persons and organizations are pooled without preference, non-Latin scripts aren't romanized, and ordering is raw code-point rather than locale-aware. All documented in the helper.

*Upgrade path:* add an ordinal column to the join tables and key on the ranked-first name. Only the helper's name selection changes — schema, query wiring and the front-end contract stay identical.

## Testing

`npm test` → **3357 passing, 0 failing**. Includes unit tests, property-based tests for the helper invariants (normalization idempotency, sentinel ordering, pool commutativity), and route-level tests pinning the `400` entity guard.

## Provenance

Extracted from #1742, authored by @dawoldo during their internship; original commits and authorship preserved. That PR bundled two independent features — this is the search half. The citation half is in the companion PR. Verified the two branches together reproduce #1742 byte-for-byte, plus a fix for the `authorsGrotto` → `authorsOrganization` rename that landed on `develop` after the original work.
