### PR TITLE
docs(permissions): document guidelines, org associations and role gating

### DIFF
--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -30,8 +30,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
     - Edit caves, entrances, documents, massifs, organisations, descriptions, locations, riggings, histories
     - Edit own comments
     - Edit own legislation guidelines
-    - Unlink documents from entities
-    - Rollback to a previous version of any content, except guidelines (own only)
+    - Rollback own legislation guidelines to a previous version (guidelines are the only entity exposing a rollback
+      route)
     - Associate/dissociate responsible organizations for any country, region, or massif
     - Add/remove own explored entrances
     - Set main name for entities
@@ -77,6 +77,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
       see "Caver Deletion")
     - Update any user's comments
     - Update/rollback any user's legislation guidelines
+    - Unlink documents from caves, entrances, and massifs
     - Update documents that have modifications pending moderator approval
     - Validate documents
     - Manage duplicates (documents and entrances)
@@ -159,7 +160,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | **Document Management**                                       |
 | Validate documents                                            | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Manage document duplicates                                    | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Unlink documents from entities                                | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Link a document to a cave/entrance/massif                     | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Unlink documents from entities                                | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Update a document with modifications pending approval         | ❌ | ❌ | ❌ | ✅ | ❌ |
 | **Scientific Domain (Devices, Sensors, Observations)**        |
 | View device/sensor configuration details                      | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -266,6 +268,14 @@ Countries, regions, and massifs can be linked to the organizations in charge of 
 - **Comment Updates**: Users can update their own comments; Moderators can update any comments
 - **Guideline Updates**: Users can update and roll back only their own guidelines; Moderators and Administrators can
   update and roll back any guideline
+
+### Document Linking
+Linking and unlinking are **not** gated symmetrically for caves, entrances, and massifs:
+- **Link** (`add-document`): any authenticated user — the controllers perform no role check at all
+- **Unlink** (`unlink-document`): `MODERATOR` only, and `ADMINISTRATOR` is *not* accepted as an alternative
+
+So an ordinary user can attach a document to a cave but cannot detach it again, and a non-Moderator Administrator
+cannot detach it either.
 
 ### Snapshot and History Access
 - **Public History**: Available to all users for non-sensitive content
@@ -406,9 +416,12 @@ If any of these are corrected in code, update the matrix rows and the "Soft Dele
   routes. Policies run in sequence, so the order decides which rejection an unauthenticated request with a malformed ID
   receives: this order returns `401` first, whereas `['validateId', 'tokenAuth']` rejects the ID before checking the token
 
-**Routes that deliberately omit `validateId`**: `v1/guideline/rollback` and `v1/guideline/get-snapshots` validate the
-`:id` in the controller instead. `validateId` requires an integer, and the guideline snapshot identifier
-(`:snapshotId`) is an ISO date string, so applying the policy would reject every otherwise-valid request.
+**Routes that deliberately omit `validateId`**: two guideline routes validate the `:id` in the controller instead, for
+different reasons:
+- `v1/guideline/rollback` — the route carries a second parameter, `:snapshotId`, which is an ISO date string.
+  `validateId` requires an integer, so applying it would reject every otherwise-valid rollback request
+- `v1/guideline/get-snapshots` — takes only a numeric `:id` and *could* use `validateId`; it omits the policy because
+  the controller already performs its own numeric check
 
 2. **Controller Level** (`RightService.hasGroup()`)
 - Role-based permission checks

--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -247,7 +247,7 @@ Guidelines are legal/regulatory notes attached to one or more geographic entitie
 - **Permanent delete**: Administrator only, via `?isPermanent=1`. Performed as a two-phase delete that first clears the
   country/region/massif junction rows and history
 - **Asymmetry to note**: authorship grants edit rights but not delete rights, so an author can amend their guideline but
-  must ask a Moderator to remove it
+  must ask a Moderator or an Administrator to remove it
 
 ### Responsible Organization Associations
 Countries, regions, and massifs can be linked to the organizations in charge of managing them and their caves.
@@ -345,8 +345,9 @@ cannot detach it either.
   - **Core content** (caves, entrances, documents, comments, descriptions, locations, riggings, histories,
     organisations, massifs): the controllers check `MODERATOR` only, so an Administrator who does not also hold the
     Moderator role cannot soft-delete or restore them
-  - **Devices, sensor configurations, guidelines**: accept either Moderator or Administrator
-  - **Restore** is Moderator-only for every entity except guidelines
+  - **Devices, sensor configurations, guidelines**: **soft deletion** accepts either Moderator or Administrator
+  - **Restore** is Moderator-only for every entity except guidelines, which again accepts either role — so devices and
+    sensor configurations accept both roles to delete but only Moderator to restore
   - **Cavers are not part of this flow at all** — deleting a caver is always permanent and there is no restore
     endpoint. See "Caver Deletion" below
 - **Permanent deletion is not uniformly Administrator-only**:
@@ -374,8 +375,23 @@ Moderator role cannot delete an author record.
 Two further rules apply regardless of role:
 - Caver id 8 (`DEFAULT_DELETED_CAVER_ID`) can never be deleted — it is the placeholder that inherits authorship of
   deleted cavers' contributions
-- Passing `entityId` merges the caver's contributions and associations into the target caver instead of orphaning
-  them; without it, authorship is reassigned to caver 8, reviewer fields are nulled, and notifications are destroyed
+- Passing `entityId` merges the caver's references into the target caver instead of orphaning them; without it,
+  `author` is reassigned to caver 8, `reviewer` is nulled, and notifications are destroyed. **This covers only the
+  fixed model list in the controller** — see the limitation below
+
+**Known limitation — the delete path does not cover every table referencing `t_caver`.** The controller reassigns an
+explicit list: the `T`/`H` pairs for caves, entrances, grottos, massifs, locations, riggings, comments, documents,
+histories, names, descriptions, plus `TCrs`, `TPoint`, the duplicate tables, notifications, `TLastChange`,
+`TTokenBlacklist`, and the caver's own collections. It does **not** touch:
+- `TGuideline` / `HGuideline` (`author`, `reviewer`)
+- `JOrganizationCountry` / `JOrganizationRegion` / `JOrganizationMassif` (`author`, `reviewer`)
+- the scientific-data tables — `t_device`, `t_sensor_configuration`, `t_observation`, `t_time_series`,
+  `t_contamination`, `t_human_activity`, `t_substance`
+
+Every one of these has a foreign key to `t_caver(id)` with **no `ON DELETE` action**, so the final `destroyOne` is
+rejected by the database if any row still points at the caver. In practice a caver who authored a guideline, an
+organization association, or any scientific-data record cannot be deleted or merged at all until those rows are
+repointed by hand. The role rules above still describe who is *authorized* to attempt the deletion.
 
 ## Known Permission Inconsistencies
 

--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -168,7 +168,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | Search devices                                                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Create devices/sensor configurations                          | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update own devices/sensor configurations                      | ❌ | ✅ | ✅ | ✅ | ✅ |
-| Update any device/sensor configuration                        | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Update any device/sensor configuration                        | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Soft delete devices/sensor configurations                     | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Restore devices/sensor configurations                         | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Permanently delete devices/sensor configurations              | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -230,8 +230,9 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 ### Organization-Based Permissions
 - **Membership Management**: Users can only manage their own organization memberships
 - **Explored Cave Management**: Organization members can add/remove explored caves for organizations they belong to
-- **Administrative Override**: Moderators and Administrators can manage any organization's explored caves and
-  memberships
+- **Administrative Override**: the two operations are gated differently — either Moderator or Administrator can manage
+  any organization's explored caves, but managing another user's memberships requires `ADMINISTRATOR` (a Moderator
+  cannot)
 
 ### Legislation Guidelines
 Guidelines are legal/regulatory notes attached to one or more geographic entities (country, region, massif).
@@ -263,8 +264,11 @@ Countries, regions, and massifs can be linked to the organizations in charge of 
   associations are still returned by reads, flagged with `isDeleted` and a `redirectTo` pointer
 
 ### Owner-Based Access Control
-- **Content Ownership**: Users can modify any content except other users' comments and other users' guidelines
-- **Moderator Override**: Moderators and Administrators can modify any content regardless of ownership
+- **Content Ownership**: Users can modify any content except other users' comments, other users' guidelines, and
+  documents that have modifications pending moderator approval (`modifiedDocJson` set)
+- **Moderator Override**: Moderators can modify any content regardless of ownership. Administrators override ownership
+  only on guidelines — updating another user's comment, or a document with pending modifications, checks `MODERATOR`
+  alone and does not accept `ADMINISTRATOR` as an alternative
 - **Comment Updates**: Users can update their own comments; Moderators can update any comments
 - **Guideline Updates**: Users can update and roll back only their own guidelines; Moderators and Administrators can
   update and roll back any guideline
@@ -289,7 +293,9 @@ cannot detach it either.
   User can bulk-create observation entities (up to a 100 MB file). **This openness is intended**: observation upload is
   a core contributor workflow, unlike the document/entrance CSV imports, which are admin-driven and require the
   Administrator role. Do not "fix" the missing role check here
-- **Owner-based update**: The original author of a device or sensor configuration can update it; Moderators can update any device or sensor configuration regardless of ownership
+- **Owner-based update**: The original author of a device or sensor configuration can update it; Moderators can update
+  any device or sensor configuration regardless of ownership. Note the in-code comment says "moderator/admin", but both
+  controllers check `MODERATOR` only, so a non-Moderator Administrator cannot update another user's device
 
 ### Ban/Unban
 - Only Administrators can ban or unban users
@@ -324,7 +330,8 @@ cannot detach it either.
 
 ### Ownership-Based Access
 - Users can modify their own content
-- Moderators and Administrators can override ownership
+- Which role overrides ownership is per-entity, not uniform: Moderator overrides it everywhere, while Administrator
+  overrides it only on guidelines. See "Owner-Based Access Control" for the exceptions
 - Organization members can manage their organization's explored caves
 
 ### Sensitive Data Protection

--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -387,11 +387,21 @@ histories, names, descriptions, plus `TCrs`, `TPoint`, the duplicate tables, not
 - `JOrganizationCountry` / `JOrganizationRegion` / `JOrganizationMassif` (`author`, `reviewer`)
 - the scientific-data tables — `t_device`, `t_sensor_configuration`, `t_observation`, `t_time_series`,
   `t_contamination`, `t_human_activity`, `t_substance`
+- `TTimeSeriesQualityLog.changedBy` (`t_time_series_quality_log.changed_by`) and `TJobBatch.initiator`
+  (`t_job_batch.id_initiator`)
 
-Every one of these has a foreign key to `t_caver(id)` with **no `ON DELETE` action**, so the final `destroyOne` is
-rejected by the database if any row still points at the caver. In practice a caver who authored a guideline, an
-organization association, or any scientific-data record cannot be deleted or merged at all until those rows are
-repointed by hand. The role rules above still describe who is *authorized* to attempt the deletion.
+Every one of these has a foreign key to `t_caver(id)` with **no `ON DELETE` action**, so a single surviving row is
+enough to make the final `destroyOne` fail.
+
+**The failure is not clean.** All of the reassignments, collection cleanups, and notification/`TLastChange` deletions
+run *before* `TCaver.destroyOne`, and the controller uses no transaction, so those writes have already committed by the
+time the delete is rejected. A blocked deletion therefore leaves the caver **partially merged**: contributions in the
+handled tables are already repointed at the merge target (or at caver 8), group memberships, subscriptions, and
+explored-entrance links are already cleared, and notifications are already destroyed — while the caver row itself
+survives, still referenced by whichever unhandled table blocked the delete. Re-running the request after repointing
+those rows by hand will complete the deletion, but the intermediate state is not recoverable by retrying alone.
+
+The role rules above still describe who is *authorized* to attempt the deletion.
 
 ## Known Permission Inconsistencies
 

--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -73,6 +73,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
     - Delete/restore legislation guidelines (permanent deletion of these requires Administrator)
     - Delete/restore devices and sensor configurations (permanent deletion of these requires Administrator)
     - Update any device or sensor configuration (regardless of ownership)
+    - Permanently delete author records (`type: AUTHOR`; deleting a `CAVER` account requires Administrator instead —
+      see "Caver Deletion")
     - Update any user's comments
     - Update/rollback any user's legislation guidelines
     - Update documents that have modifications pending moderator approval
@@ -90,7 +92,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
   - **User Management**:
     - Assign/remove user roles
     - Manage any user accounts
-    - Delete user accounts
+    - Permanently delete caver accounts (`type: CAVER`; deleting an `AUTHOR` record requires Moderator instead —
+      see "Caver Deletion")
     - Ban/unban users (revokes all active tokens)
     - View user lists (authors, contributors, users, banned, invalid-email)
     - View complete user information
@@ -197,7 +200,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | View banned users list                                        | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Ban/unban users                                               | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Manage user roles                                             | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Delete user accounts                                          | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Delete a caver account (`type: CAVER`, permanent)             | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Delete an author record (`type: AUTHOR`, permanent)           | ❌ | ❌ | ❌ | ✅ | ❌ |
 | **Authentication & MFA**                                      |
 | Enroll MFA (generate TOTP secret)                             | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Verify MFA enrollment                                         | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -324,8 +328,10 @@ Countries, regions, and massifs can be linked to the organizations in charge of 
   - **Core content** (caves, entrances, documents, comments, descriptions, locations, riggings, histories,
     organisations, massifs): the controllers check `MODERATOR` only, so an Administrator who does not also hold the
     Moderator role cannot soft-delete or restore them
-  - **Cavers, devices, sensor configurations, guidelines**: accept either Moderator or Administrator
+  - **Devices, sensor configurations, guidelines**: accept either Moderator or Administrator
   - **Restore** is Moderator-only for every entity except guidelines
+  - **Cavers are not part of this flow at all** — deleting a caver is always permanent and there is no restore
+    endpoint. See "Caver Deletion" below
 - **Permanent deletion is not uniformly Administrator-only**:
   - For core content, the permanent path (`?isPermanent=…`) is guarded by the *same* Moderator check as the soft
     delete, with no additional Administrator check — so a Moderator can permanently delete a cave, and an
@@ -334,6 +340,25 @@ Countries, regions, and massifs can be linked to the organizations in charge of 
   - See "Known Permission Inconsistencies" below
 - Permanent deletion of devices is blocked if they have associated sensor configurations
 - Permanent deletion of sensor configurations is blocked if they have associated time series
+
+### Caver Deletion
+Cavers are the one entity with no soft-delete flow: `api/controllers/v1/caver/delete.js` ends in
+`TCaver.destroyOne`, so the row is always removed and there is no `caver/restore` endpoint. Which role is required
+depends on the caver's `type`, and the two roles are **not** interchangeable (lines 27-30):
+
+| Caver `type` | Required role   |
+|--------------|-----------------|
+| `CAVER`      | `ADMINISTRATOR` |
+| `AUTHOR`     | `MODERATOR`     |
+
+A Moderator therefore cannot delete a registered caver account, and an Administrator who does not also hold the
+Moderator role cannot delete an author record.
+
+Two further rules apply regardless of role:
+- Caver id 8 (`DEFAULT_DELETED_CAVER_ID`) can never be deleted — it is the placeholder that inherits authorship of
+  deleted cavers' contributions
+- Passing `entityId` merges the caver's contributions and associations into the target caver instead of orphaning
+  them; without it, authorship is reassigned to caver 8, reviewer fields are nulled, and notifications are destroyed
 
 ## Known Permission Inconsistencies
 

--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -13,6 +13,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Permissions**:
   - View public cave/entrance/document/organisation/massif/person data
   - Search through cave/entrance/document/organisation/massif/person/device data
+  - View legislation guidelines (list, by geographic entity, and snapshots)
+  - View the organizations responsible for a country/region/massif
   - View complete entity history
   - View statistics
   - View all organization details
@@ -24,10 +26,13 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Permissions**: All Visitor permissions plus:
   - **Content Management**:
     - Create caves, entrances, documents, massifs, organisations, comments, descriptions, locations, riggings, histories
+    - Create legislation guidelines
     - Edit caves, entrances, documents, massifs, organisations, descriptions, locations, riggings, histories
     - Edit own comments
+    - Edit own legislation guidelines
     - Unlink documents from entities
-    - Rollback to a previous version of any content
+    - Rollback to a previous version of any content, except guidelines (own only)
+    - Associate/dissociate responsible organizations for any country, region, or massif
     - Add/remove own explored entrances
     - Set main name for entities
   - **Scientific Data Management**:
@@ -63,9 +68,14 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Permissions**: All User permissions plus:
   - **Content Moderation**:
     - Delete/restore any caves, entrances, documents, comments, descriptions, locations, riggings, histories, organisations, massifs
-    - Delete/restore devices and sensor configurations
+    - **Permanently** delete those same entities — the permanent path reuses the Moderator check with no additional
+      Administrator gate (see "Known Permission Inconsistencies")
+    - Delete/restore legislation guidelines (permanent deletion of these requires Administrator)
+    - Delete/restore devices and sensor configurations (permanent deletion of these requires Administrator)
     - Update any device or sensor configuration (regardless of ownership)
     - Update any user's comments
+    - Update/rollback any user's legislation guidelines
+    - Update documents that have modifications pending moderator approval
     - Validate documents
     - Manage duplicates (documents and entrances)
   - **Advanced Access**:
@@ -92,6 +102,9 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
   - **System Operations**:
     - Import data from CSV files (documents and entrances)
     - System configuration and maintenance
+  - **Content Moderation** (guidelines only; other content moderation is Moderator-only):
+    - Update/rollback any user's legislation guidelines
+    - Delete/restore legislation guidelines
   - **Sensitive Data Management**:
     - View coordinates of sensitive entrances
     - Remove sensitive flag from entrances
@@ -99,7 +112,10 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
     - Mark/unmark massifs as sensitive (cascades to contained entrances)
     - Preview massif sensitivity impact
   - **Permanent Deletion**:
-    - Permanently delete any content (caves, entrances, documents, devices, sensor configurations, etc.)
+    - Permanently delete devices, sensor configurations, and legislation guidelines
+    - **Not** core content: permanently deleting caves, entrances, documents, comments, descriptions, locations,
+      riggings, histories, organisations, or massifs requires the Moderator role, not Administrator (see "Known
+      Permission Inconsistencies")
   - **Advanced Organization Management**:
     - Add/remove explored caves for any organization
     - Manage organization memberships for any user
@@ -114,26 +130,34 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | Search content (including devices)                            | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View statistics                                               | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View history/snapshots                                        | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View guidelines (list/by-entity/snapshots)                    | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View responsible organizations of country/region/massif       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Content Creation**                                          |
 | Create caves/entrances/documents/organisations/massifs        | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Create comments/descriptions/locations/riggings/histories     | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Create guidelines                                             | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Content Modification**                                      |
 | Update caves/entrances/documents/organisations/massifs        | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update descriptions/locations/riggings/histories              | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update own comments                                           | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Update any comment                                            | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Update/rollback own guidelines                                | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update/rollback any guideline                                 | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Set main name for entities                                    | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Move entrance to another cave                                 | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Reorder descriptions/locations/riggings/histories/comments    | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Soft-deleted Content Management**                           |
-| Soft delete any content                                       | ❌ | ❌ | ❌ | ✅ | ✅ |
-| View soft-deleted content                                     | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Restore soft-deleted content                                  | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Permanent delete                                              | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Soft delete core content (caves/entrances/documents/etc.)     | ❌ | ❌ | ❌ | ✅ | ❌ |
+| View soft-deleted content                                     | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Restore core content (caves/entrances/documents/etc.)         | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Soft delete/restore guidelines                                | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Permanently delete core content (caves/entrances/docs/etc.)   | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Permanently delete guidelines                                 | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **Document Management**                                       |
-| Validate documents                                            | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Manage document duplicates                                    | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Validate documents                                            | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Manage document duplicates                                    | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Unlink documents from entities                                | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Update a document with modifications pending approval         | ❌ | ❌ | ❌ | ✅ | ❌ |
 | **Scientific Domain (Devices, Sensors, Observations)**        |
 | View device/sensor configuration details                      | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Search devices                                                | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -147,6 +171,9 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | **Organization Management**                                   |
 | Join/leave own organizations                                  | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Revoke any user's organization membership                     | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Responsible Organization Associations**                     |
+| Associate organization with country/region/massif             | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Dissociate organization from country/region/massif            | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Explored Cave Management**                                  |
 | Add/remove explored caves (own orgs)                          | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Add/remove explored caves (any org)                           | ❌ | ❌ | ❌ | ✅ | ✅ |
@@ -200,10 +227,41 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Administrative Override**: Moderators and Administrators can manage any organization's explored caves and
   memberships
 
+### Legislation Guidelines
+Guidelines are legal/regulatory notes attached to one or more geographic entities (country, region, massif).
+
+- **Read**: Fully public — list, by-entity lookup, and snapshots require no authentication
+- **Create**: Any authenticated user; no role check. At least one country, region, or massif must be referenced
+- **Update**: Author, Moderator, or Administrator only — unlike most content, a plain user cannot edit another user's
+  guideline
+- **Rollback**: Same rule as update (rollback mutates title/description/language, so it is treated as an update).
+  Guidelines are currently the only entity exposing a rollback route
+- **Soft delete/restore**: Moderator or Administrator only — the author alone cannot delete their own guideline
+- **Permanent delete**: Administrator only, via `?isPermanent=1`. Performed as a two-phase delete that first clears the
+  country/region/massif junction rows and history
+- **Asymmetry to note**: authorship grants edit rights but not delete rights, so an author can amend their guideline but
+  must ask a Moderator to remove it
+
+### Responsible Organization Associations
+Countries, regions, and massifs can be linked to the organizations in charge of managing them and their caves.
+
+- **Read**: Public — associated organizations are returned inline by `v1/country/find`, `v1/massif/find`, and
+  `v1/region/find-by-country` (note: `v1/region/find` does not include them)
+- **Associate/dissociate**: Any authenticated user; gated only by the `tokenAuth` and `validateId` policies, with no
+  role check and no organization-membership check in the controllers or `GeoAssociationService`
+- **Not ownership-scoped**: unlike explored-cave management, a user does **not** need to belong to the organization
+  being associated
+- **Attribution**: the acting user is recorded as `author` on creation and as `reviewer` on re-association; removal is
+  not attributed
+- **Soft-deleted organizations**: cannot be newly associated (the lookup filters on `isDeleted: false`), but existing
+  associations are still returned by reads, flagged with `isDeleted` and a `redirectTo` pointer
+
 ### Owner-Based Access Control
-- **Content Ownership**: Users can modify any content except other's comments
+- **Content Ownership**: Users can modify any content except other users' comments and other users' guidelines
 - **Moderator Override**: Moderators and Administrators can modify any content regardless of ownership
 - **Comment Updates**: Users can update their own comments; Moderators can update any comments
+- **Guideline Updates**: Users can update and roll back only their own guidelines; Moderators and Administrators can
+  update and roll back any guideline
 
 ### Snapshot and History Access
 - **Public History**: Available to all users for non-sensitive content
@@ -212,7 +270,11 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 ### Scientific Domain Access
 - **Devices**: Any authenticated user can create devices; update requires ownership or Moderator role; soft delete requires Moderator or Administrator; restore requires Moderator; permanent delete requires Administrator
 - **Sensor Configurations**: Same permission model as devices — scoped under a device (nested resource)
-- **Observation Import**: Any authenticated user can import observation data via CSV/TSV
+- **Observation Import**: Any authenticated user can import observation data via CSV/TSV. `v1/observation/import` is
+  gated by `tokenAuth` alone — neither the controller nor `ObservationImportService` performs a role check, so a plain
+  User can bulk-create observation entities (up to a 100 MB file). **This openness is intended**: observation upload is
+  a core contributor workflow, unlike the document/entrance CSV imports, which are admin-driven and require the
+  Administrator role. Do not "fix" the missing role check here
 - **Owner-based update**: The original author of a device or sensor configuration can update it; Moderators can update any device or sensor configuration regardless of ownership
 
 ### Ban/Unban
@@ -258,10 +320,51 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 
 ### Soft Deletes
 - Content is soft-deleted (marked as deleted, not removed)
-- Only Moderators and Administrators can soft-delete and restore content
-- Only Administrators can perform permanent deletions
+- **Who may delete/restore depends on the entity** — there is no single rule, because roles are not hierarchical:
+  - **Core content** (caves, entrances, documents, comments, descriptions, locations, riggings, histories,
+    organisations, massifs): the controllers check `MODERATOR` only, so an Administrator who does not also hold the
+    Moderator role cannot soft-delete or restore them
+  - **Cavers, devices, sensor configurations, guidelines**: accept either Moderator or Administrator
+  - **Restore** is Moderator-only for every entity except guidelines
+- **Permanent deletion is not uniformly Administrator-only**:
+  - For core content, the permanent path (`?isPermanent=…`) is guarded by the *same* Moderator check as the soft
+    delete, with no additional Administrator check — so a Moderator can permanently delete a cave, and an
+    Administrator alone cannot
+  - Only devices, sensor configurations, and guidelines re-check for the Administrator role before hard-deleting
+  - See "Known Permission Inconsistencies" below
 - Permanent deletion of devices is blocked if they have associated sensor configurations
 - Permanent deletion of sensor configurations is blocked if they have associated time series
+
+## Known Permission Inconsistencies
+
+These record **current observed behaviour**. They follow from the fact that roles are not hierarchical (see "User Roles")
+combined with per-controller role checks that were not applied uniformly — so a capability that reads as
+"administrative" may in fact be gated on the Moderator group alone.
+
+Items 1, 4 and 5 are tracked in
+[#1796](https://github.com/GrottoCenter/grottocenter-api/issues/1796). Items 2 and 3 are **accepted behaviour**: in
+practice Administrators are granted every group, so they cumulate Moderator powers and are not blocked.
+
+1. **Moderators can permanently delete core content.** For caves, entrances, documents, comments, descriptions,
+   locations, riggings, histories, organisations, and massifs, the `isPermanent` branch of the delete controller is
+   reached after only a `MODERATOR` check — for example `api/controllers/v1/cave/delete.js` checks `MODERATOR` at the
+   top and then acts on `req.param('isPermanent')` with no further gate. Devices, sensor configurations, and guidelines
+   do re-check for `ADMINISTRATOR`. This is the widest gap in the model — a Moderator can irreversibly destroy core
+   content while a non-Moderator Administrator cannot delete it at all. Tracked in #1796.
+2. **Administrators cannot moderate core content** — *accepted, not a defect.* An Administrator who does not also hold
+   the Moderator role receives a 403 when soft-deleting or restoring core content, validating a document, or managing
+   duplicates. Administrators are normally granted all groups, so they cumulate Moderator powers in practice. The matrix
+   marks these ❌ for Administrator because it records what each role grants **on its own**.
+3. **Administrators cannot see soft-deleted content** — *accepted, same reasoning as #2.* The `find` controllers for
+   caves, entrances, documents, massifs, and organisations check `MODERATOR` only before revealing deleted records; a
+   non-Moderator Administrator gets the redacted `toDeletedEntity` shape, and `cave/find.js` additionally forces
+   `isDeleted = false` on list queries.
+4. **Restore is Moderator-only almost everywhere.** 12 of 13 restore controllers check `MODERATOR` alone; guideline is
+   the outlier, accepting either role. Tracked in #1796.
+5. **Delete and restore disagree within the same entity.** `device`, `sensor-configuration` and `guideline` all accept
+   either role to *delete*, but only `guideline` accepts either role to *restore*. Tracked in #1796.
+
+If any of these are corrected in code, update the matrix rows and the "Soft Deletes" section together.
 
 ## Architecture
 
@@ -274,6 +377,13 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - `'mfaEnrollmentAuth'` - Requires valid MFA enrollment token
 - `['validateId']` - Public access with ID validation
 - `['validateId', 'tokenAuth']` - Authenticated with ID validation
+- `['tokenAuth', 'validateId']` - Same pair in the opposite order, used by the responsible-organization association
+  routes. Policies run in sequence, so the order decides which rejection an unauthenticated request with a malformed ID
+  receives: this order returns `401` first, whereas `['validateId', 'tokenAuth']` rejects the ID before checking the token
+
+**Routes that deliberately omit `validateId`**: `v1/guideline/rollback` and `v1/guideline/get-snapshots` validate the
+`:id` in the controller instead. `validateId` requires an integer, and the guideline snapshot identifier
+(`:snapshotId`) is an ISO date string, so applying the policy would reject every otherwise-valid request.
 
 2. **Controller Level** (`RightService.hasGroup()`)
 - Role-based permission checks


### PR DESCRIPTION
## 🤔 What

Brings `PERMISSION_SYSTEM.md` back in line with the code. Documentation only — no behaviour changes.

- Documents **legislation guidelines** (#1452) across the role sections, the permission matrix and a new Special Permission Cases subsection
- Documents **responsible organization associations** (#1598) the same way
- Corrects **six matrix rows** that credited Administrators with powers the controllers gate on `MODERATOR`
- Splits the delete/restore rows by entity class, because no single rule covers them
- Adds a **Known Permission Inconsistencies** section separating the defects tracked in #1796 from behaviour that is accepted
- Records that the open `v1/observation/import` endpoint is intentionally unrestricted
- Documents the `['tokenAuth', 'validateId']` ordering and the two guideline routes that skip `validateId` on purpose

## 🤷‍♂️ Why

Both features shipped **after** the doc's last update (`7f7a4db8`, 15 June) yet appeared nowhere in it: guidelines landed 4 June (`2fb9fa36`), organization associations 25 June (`7902a330`). A grep for `guideline`, `legislation`, `regulation` or `responsible` returned nothing.

Two claims had also become wrong rather than merely incomplete:

- *"Users can modify any content except other's comments"* — guidelines are a second exception
- *"Rollback to a previous version of any content"* — guidelines are own-only, and are the **only** entity with a rollback route, so the single thing this claim described was the thing it got wrong

Auditing the rest of the matrix then surfaced six rows resting on the assumption that Administrator is a superset of Moderator — which the doc's own preamble explicitly denies. Being wrong in the *permissive* direction is the risk here: a reader planning a change may conclude a destructive operation is admin-gated when it is not.

## 🔍 How

Every row was checked against the controller that enforces it, not against the surrounding prose.

The corrected rows are soft delete, restore, permanent delete, view soft-deleted content, validate documents, and manage document duplicates. All six had ✅ for Administrator where the controller checks `MODERATOR` alone.

Delete and restore are now split by entity class, since one row cannot express the real rule:

| Operation | Moderator-only | Either role | Administrator-only |
|---|---|---|---|
| Soft delete | 10 core entities | caver, device, sensor-config, guideline | — |
| Restore | 12 entities | guideline | — |
| Permanent delete | 10 core entities | — | device, sensor-config, guideline |

The `Known Permission Inconsistencies` section then draws the distinction the matrix cannot:

- **Tracked as defects** (#1796) — Moderators can permanently delete core content; the two restore-gating outliers
- **Accepted** — Administrators lacking moderation powers, since in practice they hold every group and cumulate them. The matrix still marks these ❌ because it records what each role grants *on its own*

The observation-import note is deliberately emphatic ("Do not 'fix' the missing role check here"). Its absent role check is indistinguishable from an oversight when reading the code, and it had already been flagged as a gap once during this audit before being confirmed intentional.

## 🧪 Testing

No tests apply — `npm run lint` is scoped to `**/*.js`, so this file is outside it, and there is no markdown linter configured.

Verified manually instead:

- Every matrix row traced to its enforcing controller
- Table integrity checked with an `awk` column-count pass across all rows
- All referenced issue numbers resolved via `gh issue view`

One correction worth flagging for review: I initially attributed the guideline permanent-delete work to `#1208`, taken from the `Fix/1208` branch name. In this repo `#1208` is an unrelated Dependabot PR — the number refers to an issue elsewhere — so that reference was dropped rather than left as a misleading cross-link.

## 📸 Previews

N/A — markdown only.

## Related

- #1796 — the authorization gaps this doc now records (opened alongside this work)
- #1452 — legislation guidelines
- #1598 — organization responsible for geographic entity
