### PR TITLE
test(search): fix flaky authorsSort property generators

### DIFF
--- a/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
@@ -47,9 +47,18 @@ const namesArb = fc.array(fc.oneof(nameArb, fc.constantFrom(null, undefined)), {
   maxLength: 5,
 });
 
-/** Arbitrary: a list holding at least one name that survives normalization. */
-const nonEmptyNamesArb = namesArb.filter((names) =>
-  names.some((n) => typeof n === 'string' && n.trim().length > 0)
+/**
+ * Arbitrary: a list holding at least one name that survives normalization.
+ *
+ * Survival is decided by asking the helper itself, not by `.trim()`: `trim`
+ * only strips whitespace, while normalizeName strips combining marks first, so
+ * a name made purely of diacritics is non-blank to `trim` yet normalizes away.
+ * U+1FDD, say, decomposes under NFKD to a space plus two combining marks and
+ * leaves nothing behind — a `trim`-based precondition would hand such a name to
+ * the properties below as "authored" and they would rightly disagree.
+ */
+const nonEmptyNamesArb = namesArb.filter(
+  (names) => computeDocumentAuthorsSort(names) !== EMPTY_AUTHORS_SORT_KEY
 );
 
 /** Strip the ordering bucket prefix to recover the normalized name. */

--- a/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
+++ b/test/integration/2_utils/computeDocumentAuthorsSort.property.test.js
@@ -24,8 +24,14 @@ const nameArb = fc.oneof(
     maxLength: 15,
   }),
   fc.string({
+    // Iterate by code point, not by `.split('')`: the astral-plane samples
+    // below (U+2000B, U+2A600) are two UTF-16 code units each, so splitting by
+    // code unit would offer their surrogate halves as standalone units and
+    // generate names holding lone surrogates. Those have no UTF-8 encoding —
+    // every one of them serializes to U+FFFD — which collapses names this
+    // helper orders as distinct and makes Property 4 fail on ~9% of seeds.
     unit: fc.constantFrom(
-      ...'ЯрославльΩμέγα山田太郎홍길동محمدמשהสมชาย𠀋𪘀'.split(''),
+      ...'ЯрославльΩμέγα山田太郎홍길동محمدמשהสมชาย𠀋𪘀',
       '\u{10FFFD}',
       '�',
       '~'


### PR DESCRIPTION
Extracted from #1798 at review request — these two fixes are unrelated to that PR's guideline work.

## 🤔 What

Two fixes to the generators in `computeDocumentAuthorsSort.property.test.js`. No production code changes; the behaviour under test is unchanged.

## 🤷‍♂️ Why

Both were **flaky-test bugs, not helper bugs** — the properties were failing on a minority of seeds because the test's own generators produced inputs that didn't mean what the properties assumed.

- **Lone surrogates broke byte-order minimality.** The non-Latin name arbitrary split its astral-plane samples with `.split('')`, which cuts on UTF-16 code units: `U+2000B` and `U+2A600` each became two standalone surrogate halves. Lone surrogates have no UTF-8 encoding and all serialize to `U+FFFD`, which ties names that `compareByCodePoint` ranks as distinct — failing the minimality property on **~9% of seeds**. Spreading the string iterates code points instead, keeping both characters whole.

- **A precondition re-implemented normalization and got it wrong.** `nonEmptyNamesArb` gated on `n.trim().length > 0`, but `normalizeName` strips combining marks *before* trimming, so a name made purely of diacritics is non-blank to `trim` yet normalizes to nothing. `U+1FDD` decomposes under NFKD to a space plus two combining marks and leaves nothing behind, so the filter passed it in as "authored" while the helper correctly returned the authorless key — failing on **~0.25% of seeds**. The fix asks `computeDocumentAuthorsSort` itself whether a list survives rather than duplicating its normalization in the precondition.

The second is the more interesting one: a precondition that restates logic under test will drift from it, and the drift shows up as an intermittent failure that looks like a helper bug.

## 🔍 How

Generator-only changes in one file. The filter still keeps ~63% of generated lists, spanning every script the arbitrary covers, so coverage isn't narrowed to dodge the failures.

## 🧪 Testing

6 passing locally; `npm run lint` clean. Minimality now holds on 300/300 seeds (was ~91%).

## 🔗 Related

- Split out of #1798 per review feedback.
