### PR TITLE
feat(organization): surface authored and published documents separately

### DIFF
--- a/api/controllers/v1/organization/delete.js
+++ b/api/controllers/v1/organization/delete.js
@@ -112,10 +112,16 @@ module.exports = async (req, res) => {
       await JGrottoCaveExplorer.destroy({ grotto: organizationId });
     }
 
-    if (organization.documents.length > 0) {
+    // Authorship links must be read uncapped and straight from the association:
+    // the populated organization only carries a preview page of the documents it
+    // authored, which would silently drop the rest of the authorship rows.
+    const { documents: authoredDocuments } =
+      await TGrotto.findOne(organizationId).populate('documents');
+
+    if (authoredDocuments.length > 0) {
       if (shouldMergeInto) {
         const existingDocuments = mergeIntoEntity.documents.map((e) => e.id);
-        const documentsToAdd = organization.documents
+        const documentsToAdd = authoredDocuments
           .map((e) => e.id)
           .filter((e) => !existingDocuments.includes(e));
         await TGrotto.addToCollection(mergeIntoId, 'documents', documentsToAdd);

--- a/api/services/CaverService.js
+++ b/api/services/CaverService.js
@@ -61,7 +61,11 @@ module.exports = {
    */
   getCaver: async (caverId) => {
     const caver = await TCaver.findOne(caverId)
+      // `authoredCount` below carries the real total. Deleted documents are
+      // filtered in the query rather than afterwards, so they cannot consume
+      // one of the slots.
       .populate('documents', {
+        where: { isDeleted: false },
         limit: 10,
         sort: [{ dateInscription: 'DESC' }],
       })
@@ -82,7 +86,14 @@ module.exports = {
       ? 'CAVER'
       : 'AUTHOR';
 
-    await Promise.all([
+    // Required here rather than at the top of the file: DocumentService pulls in
+    // utils/csvHelper, which requires this service back, so a top-level capture
+    // would resolve to a half-initialised module.
+    // eslint-disable-next-line global-require
+    const DocumentService = require('./DocumentService');
+
+    const [authoredCount] = await Promise.all([
+      DocumentService.countAuthoredByCaver(caverId),
       NameService.setNames(caver.exploredEntrances, 'entrance'),
       NameService.setNames(caver.grottos, 'grotto'),
       NameService.setNames(caver.subscribedToMassifs, 'massif'),
@@ -100,6 +111,7 @@ module.exports = {
       grottos: caver.grottos,
       exploredEntrances: caver.exploredEntrances,
       documents: caver.documents,
+      authoredCount,
       subscribedToMassifs: caver.subscribedToMassifs,
       subscribedToCountries: caver.subscribedToCountries,
       subscribedToRegions: caver.subscribedToRegions,

--- a/api/services/DocumentService.js
+++ b/api/services/DocumentService.js
@@ -21,6 +21,25 @@ const {
 const normalizeToId = (item) =>
   item != null && typeof item === 'object' ? (item.id ?? item) : item;
 
+// Authorship is a many-to-many relation, which Waterline's count() cannot
+// filter on, hence the native queries. Both exclude soft-deleted documents so
+// the count agrees with the lists the callers render alongside it.
+const COUNT_DOCUMENTS_AUTHORED_BY_GROTTO = `
+  SELECT COUNT(d.id)::integer AS count
+  FROM j_document_grotto_author AS j
+  JOIN t_document AS d ON d.id = j.id_document
+  WHERE j.id_grotto = $1
+  AND d.is_deleted = false
+`;
+
+const COUNT_DOCUMENTS_AUTHORED_BY_CAVER = `
+  SELECT COUNT(d.id)::integer AS count
+  FROM j_document_caver_author AS j
+  JOIN t_document AS d ON d.id = j.id_document
+  WHERE j.id_caver = $1
+  AND d.is_deleted = false
+`;
+
 // Maps a populated authorsOrganization array to the Typesense-ready shape.
 // Exported so property tests can exercise the actual function rather than a copy.
 const mapAuthorsOrganizationForSearch = (orgs) =>
@@ -600,6 +619,34 @@ module.exports = {
     return documents;
   },
 
+  /**
+   * Total number of non-deleted documents authored by an organization.
+   * Unbounded, unlike the capped list the organization payload carries, so the
+   * UI can show "10 of 1954" and link out to a filtered search.
+   * @param {Integer} organizationId
+   * @returns {Promise<Integer>}
+   */
+  countAuthoredByOrganization: async (organizationId) => {
+    const result = await sails.sendNativeQuery(
+      COUNT_DOCUMENTS_AUTHORED_BY_GROTTO,
+      [organizationId]
+    );
+    return result.rows[0]?.count ?? 0;
+  },
+
+  /**
+   * Total number of non-deleted documents authored by a caver.
+   * @param {Integer} caverId
+   * @returns {Promise<Integer>}
+   */
+  countAuthoredByCaver: async (caverId) => {
+    const result = await sails.sendNativeQuery(
+      COUNT_DOCUMENTS_AUTHORED_BY_CAVER,
+      [caverId]
+    );
+    return result.rows[0]?.count ?? 0;
+  },
+
   getDocumentChildren: async (documentId) =>
     TDocument.find({ parent: documentId })
       .populate('descriptions')
@@ -650,38 +697,6 @@ module.exports = {
     if (!entrance) return [];
 
     return entrance.documents.map((doc) => ({ id: doc.id }));
-  },
-
-  getCollectionAncestors: async (documentIds) => {
-    if (documentIds.length === 0) return [];
-
-    // The CYCLE clause (PostgreSQL 14+) detects when a row has already appeared
-    // in the recursive path and stops traversal, so cyclic data (e.g. a document
-    // that is its own parent) can never produce an infinite loop.
-    const query = `
-      WITH RECURSIVE doc_hierarchy AS (
-        SELECT id, id_parent, id_type
-        FROM t_document
-        WHERE id = ANY($1)
-
-        UNION ALL
-
-        SELECT d.id, d.id_parent, d.id_type
-        FROM t_document d
-        JOIN doc_hierarchy dh ON d.id = dh.id_parent
-      )
-      CYCLE id SET is_cycle USING path
-      SELECT DISTINCT dh.id
-      FROM doc_hierarchy dh
-      JOIN t_type t ON dh.id_type = t.id
-      WHERE t.name = 'Collection'
-        AND dh.is_cycle = false
-    `;
-
-    const result = await sails.sendNativeQuery(query, [documentIds]);
-    const collectionIds = result.rows.map((row) => row.id);
-
-    return module.exports.getDocuments(collectionIds);
   },
 
   /**

--- a/api/services/GrottoService.js
+++ b/api/services/GrottoService.js
@@ -8,6 +8,11 @@ const RecentChangeService = require('./RecentChangeService');
 const coerceToNumeric = require('../utils/coerceToNumeric');
 const trimIfString = require('../utils/trimIfString');
 
+// An organization can author or publish thousands of documents (the FFS
+// publishes ~2000), so the payload carries a preview page and a total count
+// instead of the whole set. Matches the cap CaverService uses for cavers.
+const DOCUMENTS_PREVIEW_LIMIT = 10;
+
 module.exports = {
   // Extract everything from a request body except id
   getConvertedDataFromClientRequest: (req) => ({
@@ -32,7 +37,14 @@ module.exports = {
       .populate('names')
       .populate('cavers')
       .populate('country')
-      .populate('documents')
+      // Only the most recent few are rendered; `authoredCount` below carries the
+      // real total. Deleted documents are filtered in the query rather than
+      // afterwards, so they cannot consume one of the slots.
+      .populate('documents', {
+        where: { isDeleted: false },
+        limit: DOCUMENTS_PREVIEW_LIMIT,
+        sort: [{ dateInscription: 'DESC' }],
+      })
       .populate('exploredCaves')
       .populate('partnerCaves')
       .populate('managedCountries')
@@ -88,20 +100,47 @@ module.exports = {
     delete organization.exploredCaves;
     delete organization.partnerCaves;
 
-    // Get documents where organization is author (existing functionality)
-    const authorDocIds = organization.documents.map((e) => e.id);
+    // Authoring and publishing are distinct editorial relations, so they are
+    // reported as two separate lists rather than merged: an organization that
+    // wrote a topo is not the same as one that published someone else's.
+    const authoredIds = organization.documents.map((e) => e.id);
+    const publishedDocs = await TDocument.find({
+      editor: organizationId,
+      isDeleted: false,
+    })
+      .limit(DOCUMENTS_PREVIEW_LIMIT)
+      .sort([{ dateInscription: 'DESC' }]);
 
-    // Get documents where organization is editor
-    const editorDocs = await TDocument.find({ editor: organizationId });
+    const publishedIds = publishedDocs.map((d) => d.id);
 
-    // Combine both sets of documents and remove duplicates
-    const allDocIds = [
-      ...new Set([...authorDocIds, ...editorDocs.map((d) => d.id)]),
-    ];
+    const [
+      authoredDocuments,
+      publishedDocuments,
+      authoredCount,
+      publishedCount,
+    ] = await Promise.all([
+      DocumentService.getDocumentsForCitation(authoredIds),
+      DocumentService.getDocumentsForCitation(publishedIds),
+      DocumentService.countAuthoredByOrganization(organizationId),
+      TDocument.count({ editor: organizationId, isDeleted: false }),
+    ]);
 
-    // Get Collection ancestors of all organization documents
-    organization.documents =
-      await DocumentService.getCollectionAncestors(allDocIds);
+    // getDocumentsForCitation re-queries by id, which loses the ordering the two
+    // capped selections above were made with, so restore it here — the lists are
+    // a "most recent first" preview and the frontend renders them as given.
+    const orderByIds = (ids, documents) => {
+      const byId = new Map(documents.map((d) => [d.id, d]));
+      return ids.map((id) => byId.get(id)).filter(Boolean);
+    };
+
+    delete organization.documents;
+    organization.authoredDocuments = orderByIds(authoredIds, authoredDocuments);
+    organization.publishedDocuments = orderByIds(
+      publishedIds,
+      publishedDocuments
+    );
+    organization.authoredCount = authoredCount;
+    organization.publishedCount = publishedCount;
 
     return organization;
   },
@@ -188,6 +227,9 @@ module.exports = {
   },
 
   async updateInSearch(populatedOrganization) {
+    // The remaining fields are spread into the search payload, so anything the
+    // `organizations` collection schema doesn't declare must be destructured
+    // out here. The document lists and their counts are display-only.
     const {
       names,
       cavers,
@@ -196,6 +238,10 @@ module.exports = {
       exploredEntrances,
       partnerNetworks,
       partnerEntrances,
+      authoredDocuments,
+      publishedDocuments,
+      authoredCount,
+      publishedCount,
       ...o
     } = populatedOrganization;
     const organization = {

--- a/api/services/mapping/converters.js
+++ b/api/services/mapping/converters.js
@@ -106,6 +106,10 @@ const c = {
       nickname: source.nickname,
       surname: source.surname,
       name: source.name,
+      // Real total behind the capped `documents` preview below. Cavers cannot
+      // be a document's editor (that relation is organization-only), so there
+      // is no publishedCount counterpart.
+      authoredCount: source.authoredCount,
       subscribedToCountries: source.subscribedToCountries?.map((e) => e.id),
       subscribedToMassifs: toList(
         'subscribedToMassifs',
@@ -803,7 +807,21 @@ const c = {
     yearBirth: source.yearBirth,
     nbCavers: source.nbCavers, // From search
     cavers: toList('cavers', source, c.toSimpleCaver),
-    documents: toList('documents', source, c.toSimpleDocument),
+    // Documents the organization wrote vs. documents it published, kept apart
+    // because they are distinct editorial relations. Both lists are a capped
+    // preview; the counts are the real totals.
+    authoredDocuments: toList(
+      'authoredDocuments',
+      source,
+      c.toCitationDocument
+    ),
+    publishedDocuments: toList(
+      'publishedDocuments',
+      source,
+      c.toCitationDocument
+    ),
+    authoredCount: source.authoredCount,
+    publishedCount: source.publishedCount,
     exploredEntrances: toList('exploredEntrances', source, c.toSimpleEntrance, {
       meta,
     }),
@@ -1059,7 +1077,10 @@ const c = {
         data = c.toOrganization(item.document, meta);
         // Strip arrays not needed in search responses
         delete data.cavers;
-        delete data.documents;
+        delete data.authoredDocuments;
+        delete data.publishedDocuments;
+        delete data.authoredCount;
+        delete data.publishedCount;
         delete data.exploredEntrances;
         delete data.exploredNetworks;
         delete data.partnerEntrances;

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -7960,8 +7960,17 @@ components:
           type: string
         '@type':
           type: string
+        authoredCount:
+          type: integer
+          description: >-
+            Total number of non-deleted documents this person authored. May exceed
+            the length of documents, which is a capped preview. There is no
+            publishedCount counterpart: only organizations can be a document's editor.
         documents:
           type: array
+          description: >-
+            Most recently registered documents authored by this person, capped at
+            10. See authoredCount for the total.
           items:
             $ref: '#/components/schemas/CitationDocument'
         exploredEntrances:
@@ -9377,6 +9386,18 @@ components:
           type: 'string'
         author:
           $ref: '#/components/schemas/Caver'
+        authoredCount:
+          type: integer
+          description: >-
+            Total number of non-deleted documents this organization authored.
+            May exceed the length of authoredDocuments, which is a capped preview.
+        authoredDocuments:
+          type: array
+          description: >-
+            Most recently registered documents authored by this organization,
+            capped at 10. See authoredCount for the total.
+          items:
+            $ref: '#/components/schemas/CitationDocument'
         cavers:
           type: array
           items:
@@ -9497,6 +9518,19 @@ components:
           type: 'string'
         postalCode:
           type: 'string'
+        publishedCount:
+          type: integer
+          description: >-
+            Total number of non-deleted documents this organization published
+            (i.e. is the editor of). May exceed the length of publishedDocuments,
+            which is a capped preview.
+        publishedDocuments:
+          type: array
+          description: >-
+            Most recently registered documents published by this organization,
+            capped at 10. See publishedCount for the total.
+          items:
+            $ref: '#/components/schemas/CitationDocument'
         region:
           type: 'string'
         reviewer:

--- a/test/integration/1_services/CaverService.test.js
+++ b/test/integration/1_services/CaverService.test.js
@@ -79,6 +79,9 @@ describe('CaverService', () => {
       should(caver.surname).equal('Cavo');
       should(caver.documents.length).equal(3);
       should(caver.documents).containDeep([{ id: 1 }, { id: 2 }, { id: 4 }]);
+      // `documents` is a capped preview, `authoredCount` the real total; here
+      // the fixture set is small enough that they agree.
+      should(caver.authoredCount).equal(3);
       should(caver.groups.length).equal(1);
       should(caver.grottos.length).equal(2);
       should(caver.grottos).containDeep([{ id: 1 }, { id: 2 }]);

--- a/test/integration/1_services/DocumentService.test.js
+++ b/test/integration/1_services/DocumentService.test.js
@@ -158,6 +158,80 @@ describe('DocumentService', () => {
     });
   });
 
+  describe('countAuthoredByOrganization()', () => {
+    let extraDocId;
+
+    afterEach(async () => {
+      if (extraDocId) {
+        await JDocumentGrottoAuthor.destroy({ document: extraDocId });
+        await TDocument.destroy({ id: extraDocId });
+        extraDocId = null;
+      }
+    });
+
+    it('should count the documents the organization authored', async () => {
+      // Fixture: organization 1 authors document 1.
+      const result = await DocumentService.countAuthoredByOrganization(1);
+      should(result).equal(1);
+    });
+
+    it('should return 0 for an organization that authored nothing', async () => {
+      const result = await DocumentService.countAuthoredByOrganization(99999);
+      should(result).equal(0);
+    });
+
+    it('should not count deleted documents', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        isDeleted: true,
+      }).fetch();
+      extraDocId = doc.id;
+      await JDocumentGrottoAuthor.create({ document: doc.id, grotto: 1 });
+
+      // The count backs a list that hides deleted documents, so a soft-deleted
+      // document must not inflate it.
+      const result = await DocumentService.countAuthoredByOrganization(1);
+      should(result).equal(1);
+    });
+  });
+
+  describe('countAuthoredByCaver()', () => {
+    let extraDocId;
+
+    afterEach(async () => {
+      if (extraDocId) {
+        await JDocumentCaverAuthor.destroy({ document: extraDocId });
+        await TDocument.destroy({ id: extraDocId });
+        extraDocId = null;
+      }
+    });
+
+    it('should count the documents the caver authored', async () => {
+      // Fixture: caver 1 authors documents 1, 2 and 4.
+      const result = await DocumentService.countAuthoredByCaver(1);
+      should(result).equal(3);
+    });
+
+    it('should return 0 for a caver that authored nothing', async () => {
+      const result = await DocumentService.countAuthoredByCaver(99999);
+      should(result).equal(0);
+    });
+
+    it('should not count deleted documents', async () => {
+      const doc = await TDocument.create({
+        author: 1,
+        type: 1,
+        isDeleted: true,
+      }).fetch();
+      extraDocId = doc.id;
+      await JDocumentCaverAuthor.create({ document: doc.id, caver: 1 });
+
+      const result = await DocumentService.countAuthoredByCaver(1);
+      should(result).equal(3);
+    });
+  });
+
   describe('getIdDocumentByEntranceId()', () => {
     it('should return empty array for null entrance', async () => {
       const result = await DocumentService.getIdDocumentByEntranceId(null);
@@ -166,18 +240,6 @@ describe('DocumentService', () => {
 
     it('should return document ids for entrance', async () => {
       const result = await DocumentService.getIdDocumentByEntranceId(1);
-      should(result).be.an.Array();
-    });
-  });
-
-  describe('getCollectionAncestors()', () => {
-    it('should return empty array for empty input', async () => {
-      const result = await DocumentService.getCollectionAncestors([]);
-      should(result).eql([]);
-    });
-
-    it('should return collection ancestors', async () => {
-      const result = await DocumentService.getCollectionAncestors([1]);
       should(result).be.an.Array();
     });
   });
@@ -849,7 +911,7 @@ describe('DocumentService', () => {
     });
   });
 
-  describe('getCollectionAncestors() - cycle safety', () => {
+  describe('checkParentCycle() - cycle safety', () => {
     let cyclicDocAId;
     let cyclicDocBId;
 
@@ -875,7 +937,7 @@ describe('DocumentService', () => {
       // data that may exist in production before the constraint was added.
       this.timeout(10000);
 
-      // Create doc A (a Collection, so getCollectionAncestors would normally walk up)
+      // Create doc A (a Collection, so the recursive CTE walks up from it)
       const docA = await TDocument.create({ author: 1, type: 1 }).fetch();
       cyclicDocAId = docA.id;
 
@@ -894,12 +956,9 @@ describe('DocumentService', () => {
         [docB.id, docA.id]
       );
 
-      // getCollectionAncestors must terminate and return a valid (possibly empty) array
-      const result = await DocumentService.getCollectionAncestors([
-        docA.id,
-        docB.id,
-      ]);
-      should(result).be.an.Array();
+      // The recursive CTE must terminate rather than loop forever on the cycle.
+      const result = await DocumentService.checkParentCycle(docA.id, docB.id);
+      should(result).be.a.Boolean();
     });
   });
 

--- a/test/integration/1_services/GrottoService.test.js
+++ b/test/integration/1_services/GrottoService.test.js
@@ -130,13 +130,103 @@ describe('GrottoService', () => {
       should(result).have.property('author');
       should(result).have.property('names');
       should(result).have.property('cavers');
-      should(result).have.property('documents');
+      should(result).have.property('authoredDocuments');
+      should(result).have.property('publishedDocuments');
+      should(result).have.property('authoredCount');
+      should(result).have.property('publishedCount');
       should(result).have.property('exploredNetworks');
       should(result).have.property('exploredEntrances');
       should(result).have.property('partnerNetworks');
       should(result).have.property('partnerEntrances');
       should(result.exploredCaves).be.undefined();
       should(result.partnerCaves).be.undefined();
+      // Superseded by the two lists above; leaving it would double-render docs.
+      should(result.documents).be.undefined();
+    });
+
+    it('should report authored and published documents separately', async () => {
+      const result = await GrottoService.getPopulatedOrganization(1);
+      should(result.authoredDocuments).be.an.Array();
+      should(result.publishedDocuments).be.an.Array();
+      should(result.authoredCount).be.a.Number();
+      should(result.publishedCount).be.a.Number();
+
+      // Each list is a preview page; the counts are the real totals, so they
+      // can never be smaller than what the lists carry.
+      should(result.authoredDocuments.length).be.lessThanOrEqual(10);
+      should(result.publishedDocuments.length).be.lessThanOrEqual(10);
+      should(result.authoredCount).be.greaterThanOrEqual(
+        result.authoredDocuments.length
+      );
+      should(result.publishedCount).be.greaterThanOrEqual(
+        result.publishedDocuments.length
+      );
+    });
+
+    it('should hydrate documents with their citation fields', async () => {
+      const result = await GrottoService.getPopulatedOrganization(1);
+      should(result.authoredDocuments.length).be.greaterThan(0);
+      // The organization page renders citations, so the lists must carry the
+      // citation joins rather than bare titles.
+      for (const document of result.authoredDocuments) {
+        should(document).have.property('authors');
+        should(document).have.property('authorsOrganization');
+        should(document).have.property('type');
+        should(document).have.property('parent');
+      }
+    });
+
+    describe('ordering', () => {
+      // The single-document fixture cannot show an ordering bug, so build a set
+      // whose registration dates run counter to the id order.
+      const createdDocIds = [];
+
+      before(async () => {
+        // Created one at a time on purpose: ids must ascend while the dates do
+        // not, so returning rows in id order would fail the assertion below.
+        /* eslint-disable no-await-in-loop */
+        const dates = ['2019-01-01', '2023-01-01', '2021-01-01'];
+        for (const date of dates) {
+          const doc = await TDocument.create({
+            author: 1,
+            type: 1,
+            editor: 1,
+            dateInscription: new Date(date),
+          }).fetch();
+          createdDocIds.push(doc.id);
+          await JDocumentGrottoAuthor.create({ document: doc.id, grotto: 1 });
+        }
+        /* eslint-enable no-await-in-loop */
+      });
+
+      after(async () => {
+        await JDocumentGrottoAuthor.destroy({ document: createdDocIds });
+        await TDocument.destroy({ id: createdDocIds });
+      });
+
+      it('should order both lists most recently registered first', async () => {
+        const result = await GrottoService.getPopulatedOrganization(1);
+        // getDocumentsForCitation re-queries by id, so without an explicit
+        // re-sort the lists come back in whatever order postgres chooses.
+        const isDescending = (documents) =>
+          documents.every(
+            (document, i) =>
+              i === 0 ||
+              new Date(documents[i - 1].dateInscription) >=
+                new Date(document.dateInscription)
+          );
+
+        should(result.authoredDocuments.length).be.greaterThan(2);
+        should(result.publishedDocuments.length).be.greaterThan(2);
+        should(isDescending(result.authoredDocuments)).be.true();
+        should(isDescending(result.publishedDocuments)).be.true();
+      });
+    });
+
+    it('should exclude deleted documents from the authored list', async () => {
+      const result = await GrottoService.getPopulatedOrganization(1);
+      should(result.authoredDocuments.every((d) => !d.isDeleted)).be.true();
+      should(result.publishedDocuments.every((d) => !d.isDeleted)).be.true();
     });
 
     it('should split caves into networks and entrances for explored', async () => {
@@ -355,6 +445,37 @@ describe('GrottoService', () => {
       should(callArg.reviewer).equal('Reviewer');
       should(callArg.country).equal('France');
       should(callArg.nbCavers).equal(2);
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should not leak the document lists into the search payload', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      const updateStub = sinon.stub(SearchService, 'updateDocument').resolves();
+
+      // updateInSearch spreads the leftover fields into the Typesense payload,
+      // so a display-only field that isn't destructured out would be indexed
+      // against a schema that doesn't declare it.
+      await GrottoService.updateInSearch({
+        id: 1,
+        author: { id: 1, nickname: 'Author' },
+        names: [{ name: 'Test Org', language: 'eng' }],
+        exploredNetworks: [],
+        exploredEntrances: [],
+        partnerNetworks: [],
+        partnerEntrances: [],
+        authoredDocuments: [{ id: 1 }],
+        publishedDocuments: [{ id: 2 }],
+        authoredCount: 1,
+        publishedCount: 1,
+      });
+
+      const callArg = updateStub.getCall(0).args[1];
+      should(callArg).not.have.property('authoredDocuments');
+      should(callArg).not.have.property('publishedDocuments');
+      should(callArg).not.have.property('authoredCount');
+      should(callArg).not.have.property('publishedCount');
+      should(callArg).not.have.property('documents');
       process.env.NODE_ENV = originalEnv;
     });
 

--- a/test/integration/4_routes/Cavers/find.test.js
+++ b/test/integration/4_routes/Cavers/find.test.js
@@ -7,6 +7,7 @@ const CAVER_PROPERTIES = [
   '@id',
   '@type',
   'id',
+  'authoredCount',
   'documents',
   'exploredEntrances',
   'organizations',

--- a/test/integration/4_routes/Organization/delete.test.js
+++ b/test/integration/4_routes/Organization/delete.test.js
@@ -183,5 +183,57 @@ describe('Organization features', () => {
         [sharedCave.id, onlyCave.id].sort()
       );
     });
+
+    it('should hand over every authored document when merging, past the preview cap', async () => {
+      const targetOrg = await TGrotto.create({ author: 1 }).fetch();
+      const org = await TGrotto.create({ author: 1, isDeleted: true }).fetch();
+
+      // More than the 10-document preview the organization payload carries: the
+      // merge must read the authorship association uncapped, or the documents
+      // past the cap are wiped rather than handed over.
+      const docs = await TDocument.createEach(
+        Array.from({ length: 12 }, () => ({ author: 1, type: 1 }))
+      ).fetch();
+      const docIds = docs.map((d) => d.id);
+
+      await JDocumentGrottoAuthor.createEach(
+        docIds.map((id) => ({ document: id, grotto: org.id }))
+      );
+      // Already shared with the survivor, so re-adding it would collide on the
+      // (id_document, id_grotto) primary key.
+      const sharedDocId = docIds[0];
+      await JDocumentGrottoAuthor.create({
+        document: sharedDocId,
+        grotto: targetOrg.id,
+      });
+
+      await supertest(sails.hooks.http.app)
+        .delete(
+          `/api/v1/organizations/${org.id}?isPermanent=true&entityId=${targetOrg.id}`
+        )
+        .set('Authorization', moderatorToken)
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      should(await TGrotto.findOne(org.id)).be.undefined();
+      should(await JDocumentGrottoAuthor.find({ grotto: org.id })).have.length(
+        0
+      );
+
+      // All 12 authorship links survive on the survivor, the shared one exactly
+      // once. Reading the capped preview instead would leave only 10.
+      const survivorLinks = await JDocumentGrottoAuthor.find({
+        grotto: targetOrg.id,
+      });
+      should(survivorLinks).have.length(12);
+      should(survivorLinks.map((r) => r.document).sort()).deepEqual(
+        [...docIds].sort()
+      );
+
+      await JDocumentGrottoAuthor.destroy({ document: docIds });
+      await TDocument.destroy({ id: docIds });
+      await TGrotto.destroy({ id: targetOrg.id });
+    });
   });
 });

--- a/test/integration/4_routes/Organization/find.test.js
+++ b/test/integration/4_routes/Organization/find.test.js
@@ -7,6 +7,10 @@ const ORGANIZATION_PROPERTIES = [
   '@type',
   'id',
   'address',
+  'authoredCount',
+  'authoredDocuments',
+  'publishedCount',
+  'publishedDocuments',
   'city',
   'country',
   'county',
@@ -65,6 +69,25 @@ describe('Organization features', () => {
           should(organization).have.properties(ORGANIZATION_PROPERTIES);
           should(organization.name).not.be.empty();
           should(organization.dateInscription).not.be.empty();
+          return done();
+        });
+    });
+
+    it('should expose authored and published documents as separate lists', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/organizations/1')
+        .set('Content-type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          const { body: organization } = res;
+          should(organization.authoredDocuments).be.an.Array();
+          should(organization.publishedDocuments).be.an.Array();
+          should(organization.authoredCount).be.a.Number();
+          should(organization.publishedCount).be.a.Number();
+          // Replaced by the two lists above.
+          should(organization).not.have.property('documents');
           return done();
         });
     });


### PR DESCRIPTION
Organization pages could not show the organization's documents, and cavers showed a truncated document count as if it were the total. Part of #1729 (item F).

## Why

- **The organization payload returned neither list.** `getPopulatedOrganization` merged documents the organization *authored* (`j_document_grotto_author`) with documents it *published* (`t_document.id_editor`), then replaced the merged set with the Collections *above* those documents. Clan des Tritons (695) authored 76 documents and published 1954; the API returned 5 unrelated Collections. G.S. Vulcain: 34 / 563, 2 returned.
- **Authoring and publishing are different editorial relations.** An organization that wrote a topo is not the same as one that published someone else's, so merging them loses meaning even once the list is correct.
- **Unbounded lists don't scale.** The FFS publishes ~2000 documents. Each list is now a 10-item preview paired with an unbounded count, so the UI can render "10 of 1954" and link out to a filtered advanced search — both filters (`authorsOrganization.name`, `editor.name`) are already live in the documents index.
- **Cavers had the same counting problem.** `documents` is capped at 10, so the frontend badge derived from `documents.length` under-reported anyone with more.

## What

- `documents` → `authoredDocuments` + `publishedDocuments`, each capped at 10 and ordered most-recent-first, hydrated with citation fields.
- New `authoredCount` / `publishedCount` on organizations, `authoredCount` on cavers. Cavers get no published counterpart — `TDocument.editor` is organization-only.
- Deleted documents are filtered in the query rather than after the cap, so they can't consume a preview slot.
- Swagger schemas for both entities.

Two fixes found while verifying, both pre-existing:

- `GrottoService.updateInSearch` spreads leftover fields into the Typesense payload; the old rollup already leaked there and the new fields would too. Now destructured out, with a regression test.
- `organization/delete.js` permanent-delete merge read the populated `documents`, which held Collection ancestors — it handed the survivor the wrong document set and then wiped the real `j_document_grotto_author` rows. Now reads the association uncapped.

`getCollectionAncestors` is dropped as unused.

## Breaking change

`documents` is gone from the organization payload. **Must ship with the companion `grottocenter-front` PR in the same release** — that PR splits the single `Collections` section into authored/published, sources counts from the server, and switches the person badge to `authoredCount`.

## Related

- Issue: #1729 (item F)