### PR TITLE
fix(guideline): allow privileged users to retrieve soft-deleted guidelines

### DIFF
--- a/PERMISSION_SYSTEM.md
+++ b/PERMISSION_SYSTEM.md
@@ -13,7 +13,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 - **Permissions**:
   - View public cave/entrance/document/organisation/massif/person data
   - Search through cave/entrance/document/organisation/massif/person/device data
-  - View legislation guidelines (list, single guideline by id, by geographic entity, and snapshots)
+  - View active legislation guidelines (list, single guideline by id, by geographic entity, and snapshots) — a
+    soft-deleted guideline yields 404 by id, though its text stays readable through snapshots
   - View the organizations responsible for a country/region/massif
   - View complete entity history
   - View statistics
@@ -71,6 +72,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
     - **Permanently** delete those same entities — the permanent path reuses the Moderator check with no additional
       Administrator gate (see "Known Permission Inconsistencies")
     - Delete/restore legislation guidelines (permanent deletion of these requires Administrator)
+    - View a soft-deleted legislation guideline by id, with the full detail representation
     - Delete/restore devices and sensor configurations (permanent deletion of these requires Administrator)
     - Update any device or sensor configuration (regardless of ownership)
     - Permanently delete author records (`type: AUTHOR`; deleting a `CAVER` account requires Administrator instead —
@@ -108,6 +110,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
   - **Content Moderation** (guideline deletion only; other content moderation is Moderator-only):
     - Delete/restore legislation guidelines — the only guideline operation an Administrator gates, since updating and
       rolling back them is open to any authenticated user
+    - View a soft-deleted legislation guideline by id — the only soft-deleted content an Administrator can read without
+      also holding the Moderator role (see "Known Permission Inconsistencies" #3)
   - **Sensitive Data Management**:
     - View coordinates of sensitive entrances
     - Remove sensitive flag from entrances
@@ -133,7 +137,7 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | Search content (including devices)                            | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View statistics                                               | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View history/snapshots                                        | ✅ | ✅ | ✅ | ✅ | ✅ |
-| View guidelines (list/by-id/by-entity/snapshots)              | ✅ | ✅ | ✅ | ✅ | ✅ |
+| View active guidelines (list/by-id/by-entity/snapshots)       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | View responsible organizations of country/region/massif       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Content Creation**                                          |
 | Create caves/entrances/documents/organisations/massifs        | ❌ | ✅ | ✅ | ✅ | ✅ |
@@ -150,7 +154,8 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 | Reorder descriptions/locations/riggings/histories/comments    | ❌ | ✅ | ✅ | ✅ | ✅ |
 | **Soft-deleted Content Management**                           |
 | Soft delete core content (caves/entrances/documents/etc.)     | ❌ | ❌ | ❌ | ✅ | ❌ |
-| View soft-deleted content                                     | ❌ | ❌ | ❌ | ✅ | ❌ |
+| View soft-deleted core content                                | ❌ | ❌ | ❌ | ✅ | ❌ |
+| View a soft-deleted guideline by id                           | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Restore core content (caves/entrances/documents/etc.)         | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Soft delete/restore guidelines                                | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Permanently delete core content (caves/entrances/docs/etc.)   | ❌ | ❌ | ❌ | ✅ | ❌ |
@@ -235,15 +240,26 @@ Roles are **not hierarchical**; for instance, an Administrator does not automati
 ### Legislation Guidelines
 Guidelines are legal/regulatory notes attached to one or more geographic entities (country, region, massif).
 
-- **Read**: Fully public — list, single-guideline lookup by id, by-entity lookup, and snapshots require no
-  authentication. The by-id route is gated `['validateId']` only, and that policy rejects through `res.notFound`, so a
-  malformed id and a missing one are indistinguishable — both yield `404`. The route also returns `404` for soft-deleted
-  guidelines **to every role**, including Moderators: unlike the core-content `find` controllers it has no `MODERATOR`
-  branch revealing deleted records. That hides the *live row* only, and does not make a deleted guideline's content
-  unreachable — `get-snapshots` is public and queries `h_guideline` by `t_id` without consulting the live row or its
-  `isDeleted` flag, while the update trigger snapshots the pre-delete title, description and language on soft-delete. An
-  unauthenticated caller can therefore still read a soft-deleted guideline's text via
-  `GET /api/v1/guidelines/:id/snapshots`. Treat soft-deleting a guideline as unpublishing it, not as redacting it
+- **Read**: Public for *active* guidelines — list, single-guideline lookup by id, by-entity lookup, and snapshots require
+  no authentication. The by-id route is gated `['validateId']` only, and that policy rejects through `res.notFound`, so a
+  malformed id and a missing one are indistinguishable — both yield `404`. Since #1804 the by-id route additionally
+  reveals **soft-deleted** guidelines to a Moderator **or** an Administrator: `guideline/find.js` reads the optional
+  `req.token` that the `parseAuthToken` middleware populates on any route and, when either group is present, returns
+  `200` with the full hydrated `GuidelineDetail` and `isDeleted: true`. It accepts either role because those are exactly
+  the two roles that can delete and restore a guideline, and unlike the core-content `find` controllers — which check
+  `MODERATOR` alone — it returns the **complete** representation, so the front end can render the deleted state and the
+  restore action after a page reload. Anonymous callers, a plain User and a Leader still receive `404`, with the same
+  message as a missing id, so the deleted row's existence is not leaked.
+  Hiding the live row was never a redaction anyway — `get-snapshots` is public and queries `h_guideline` by `t_id`
+  without consulting the live row or its `isDeleted` flag, while the update trigger snapshots the pre-delete title,
+  description and language on soft-delete, so an unauthenticated caller can still read a soft-deleted guideline's text
+  via `GET /api/v1/guidelines/:id/snapshots`. Treat soft-deleting a guideline as unpublishing it, not as redacting it
+- **Write paths still refuse a deleted guideline**: `PATCH /guidelines/:id` and
+  `POST /guidelines/:id/rollback/:snapshotId` return `404` when `isDeleted` is true, for **every** role including
+  Moderators and Administrators (matching `entrance/update.js`, `massif/update.js` and `device/update.js`). Restore is
+  the only operation that accepts a deleted row. So a Moderator can now *read* a deleted guideline but still cannot edit
+  it in place — which is also what keeps the audit trail honest, since `change_guideline()` only emits an `update` row in
+  `t_last_change` when `NEW.is_deleted = false`
 - **Create**: Any authenticated user; no role check. At least one country, region, or massif must be referenced
 - **Update**: Any authenticated user; no ownership and no role check — `tokenAuth` is the only gate, so a plain user can
   edit another user's guideline, as with most other content
@@ -436,11 +452,16 @@ practice Administrators are granted every group, so they cumulate Moderator powe
 3. **Administrators cannot see soft-deleted content** — *accepted, same reasoning as #2.* The `find` controllers for
    caves, entrances, documents, massifs, and organisations check `MODERATOR` only before revealing deleted records; a
    non-Moderator Administrator gets the redacted `toDeletedEntity` shape, and `cave/find.js` additionally forces
-   `isDeleted = false` on list queries.
+   `isDeleted = false` on list queries. Guidelines are the exception since #1804: `guideline/find.js` checks Moderator
+   **or** Administrator and returns the full representation, aligning the read gate with that entity's delete and restore
+   gates. If the core-content `find` controllers are ever widened the same way, update this item and the matrix rows
+   together.
 4. **Restore is Moderator-only almost everywhere.** 12 of 13 restore controllers check `MODERATOR` alone; guideline is
    the outlier, accepting either role. Tracked in #1796.
 5. **Delete and restore disagree within the same entity.** `device`, `sensor-configuration` and `guideline` all accept
-   either role to *delete*, but only `guideline` accepts either role to *restore*. Tracked in #1796.
+   either role to *delete*, but only `guideline` accepts either role to *restore*. Since #1804 `guideline` is also the
+   only entity whose `find` accepts either role, so its read, delete and restore gates all agree with each other while
+   diverging from every other entity. Tracked in #1796.
 6. **Guidelines are writable by anyone but deletable only by Moderators or Administrators.** `guideline/update` and
    `guideline/rollback` perform no ownership or role check, so any authenticated user can rewrite or roll back any
    guideline, while `guideline/delete` requires Moderator or Administrator. Rollback is the sharper edge: it replaces

--- a/api/controllers/v1/guideline/find.js
+++ b/api/controllers/v1/guideline/find.js
@@ -1,15 +1,47 @@
 const ControllerService = require('../../../services/ControllerService');
 const GuidelineService = require('../../../services/GuidelineService');
+const RightService = require('../../../services/RightService');
 const { toGuideline } = require('../../../services/mapping/converters');
 
 module.exports = async (req, res) => {
   const guidelineId = req.param('id');
+
+  // No tokenAuth policy — the endpoint stays publicly readable for active
+  // guidelines. The `parseAuthToken` middleware (config/http.js) still populates
+  // req.token whenever a valid Bearer token is sent, on any route, so guard the
+  // access to avoid crashes on anonymous requests. Same pattern as
+  // device/find.js, entrance/find.js, cave/find.js, massif/find.js.
+  //
+  // Both Moderator and Administrator may see soft-deleted guidelines: those are
+  // exactly the two roles that can delete and restore one (guideline/delete.js,
+  // guideline/restore.js). Roles are not hierarchical here, hence two
+  // independent checks rather than the single MODERATOR test the core-content
+  // find controllers use — that test would lock a non-Moderator Administrator
+  // out of content they are allowed to delete.
+  const isModerator = RightService.hasGroup(
+    req.token?.groups,
+    RightService.G.MODERATOR
+  );
+  const isAdmin = RightService.hasGroup(
+    req.token?.groups,
+    RightService.G.ADMINISTRATOR
+  );
+  const canViewDeleted = isModerator || isAdmin;
+
   const guideline = await GuidelineService.getGuidelineDetail(guidelineId);
-  if (!guideline || guideline.isDeleted) {
+
+  // A missing guideline and a soft-deleted one this caller may not see must be
+  // indistinguishable, so both exit through the same message. Privileged callers
+  // fall through to the full hydrated GuidelineDetail with `isDeleted: true` —
+  // deliberately not the reduced `toDeletedEntity` shape used by
+  // entrance/cave/massif, because the front end needs the whole record to render
+  // the deleted state and the restore action after a page reload.
+  if (!guideline || (guideline.isDeleted && !canViewDeleted)) {
     return res.notFound({
       message: `Guideline of id ${guidelineId} not found.`,
     });
   }
+
   return ControllerService.treatAndConvert(
     req,
     null,

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3553,6 +3553,13 @@ paths:
         `GuidelineDetail` response with `isDeleted: true`. Anonymous and
         unprivileged callers receive `404` for a soft-deleted guideline, with the
         same message as for a genuinely missing one.
+      # Optional authentication: the empty requirement keeps the operation
+      # callable anonymously, while `bearerAuth` tells tooling a token may be
+      # sent — without it, Swagger UI and generated clients would omit the
+      # configured token and could never reach the privileged deleted view.
+      security:
+        - {}
+        - bearerAuth: []
       parameters:
         - name: id
           in: path

--- a/assets/swaggerV1.yaml
+++ b/assets/swaggerV1.yaml
@@ -3545,9 +3545,14 @@ paths:
       tags:
         - guidelines
       description: >-
-        Get a single guideline by ID. Public endpoint — no authentication
-        required. Geographic relations and the language are hydrated with
-        readable names (see `GuidelineDetail`).
+        Get a single guideline by ID. Public endpoint — no authentication is
+        required for an active guideline. Geographic relations and the language
+        are hydrated with readable names (see `GuidelineDetail`). Soft-deleted
+        guidelines are only visible to authenticated callers holding the
+        Moderator or the Administrator role, who receive the same full
+        `GuidelineDetail` response with `isDeleted: true`. Anonymous and
+        unprivileged callers receive `404` for a soft-deleted guideline, with the
+        same message as for a genuinely missing one.
       parameters:
         - name: id
           in: path
@@ -3563,7 +3568,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/GuidelineDetail'
         '404':
-          description: Guideline not found or soft-deleted.
+          description: >-
+            Guideline not found, or soft-deleted and the caller is neither a
+            Moderator nor an Administrator.
           content:
             application/json:
               schema:
@@ -8851,6 +8858,10 @@ components:
           nullable: true
         isDeleted:
           type: boolean
+          description: >-
+            True for a soft-deleted guideline. `GET /guidelines/{id}` only ever
+            returns `true` here to a Moderator or an Administrator; every other
+            caller receives `404` instead.
         author:
           $ref: '#/components/schemas/Caver'
         reviewer:

--- a/test/integration/4_routes/Guidelines/find.test.js
+++ b/test/integration/4_routes/Guidelines/find.test.js
@@ -1,7 +1,11 @@
 const supertest = require('supertest');
 const should = require('should');
+const AuthTokenService = require('../../AuthTokenService');
 
 // Requirements: 2.5, 2.6, 2.7, 2.8, 2.9
+// Req 2.8's "404 for a soft-deleted guideline" now holds only for anonymous and
+// unprivileged callers: since #1804 a Moderator or an Administrator receives 200
+// with the full hydrated detail and `isDeleted: true`.
 describe('Guideline find', () => {
   // Guidelines dedicated to this file. Sibling test files in this same folder
   // mutate the seeded rows — update.test.js clears guideline 1's geographic
@@ -11,9 +15,20 @@ describe('Guideline find', () => {
   // (mirroring rollback.test.js).
   let guidelineId;
   let deletedGuidelineId;
+  let deletedWithGeoGuidelineId;
+  let roundTripGuidelineId;
   let unreviewedGuidelineId;
+  let moderatorToken;
+  let adminToken;
+  let userToken;
+  let leaderToken;
 
   before(async () => {
+    moderatorToken = await AuthTokenService.getRawBearerModeratorToken();
+    adminToken = await AuthTokenService.getRawBearerAdminToken();
+    userToken = await AuthTokenService.getRawBearerUserToken();
+    leaderToken = await AuthTokenService.getRawBearerLeaderToken();
+
     const guideline = await TGuideline.create({
       title: 'Find Detail Guideline',
       description: 'A guideline owned by find.test.js.',
@@ -36,6 +51,49 @@ describe('Guideline find', () => {
       isDeleted: true,
     }).fetch();
     deletedGuidelineId = deleted.id;
+
+    // A soft-deleted guideline that still carries its geographic associations, so
+    // the privileged view can be asserted on the same hydrated shape as an active
+    // one. Deleted through `destroyOne` rather than created with
+    // `isDeleted: true`: the `histo_delete` trigger turns the DELETE into an
+    // UPDATE, and going through it is what proves the junction rows survive a
+    // real soft delete (the contract guideline/delete.js relies on when it echoes
+    // the pre-delete associations back).
+    const deletedWithGeo = await TGuideline.create({
+      title: 'Deleted Guideline With Geo For Find Test',
+      description: 'A soft-deleted guideline owned by find.test.js.',
+      author: 3,
+      reviewer: 2,
+      language: 'fra',
+      dateInscription: new Date(),
+    }).fetch();
+    deletedWithGeoGuidelineId = deletedWithGeo.id;
+    await TGuideline.addToCollection(deletedWithGeoGuidelineId, 'countries', [
+      'FR',
+    ]);
+    await TGuideline.addToCollection(deletedWithGeoGuidelineId, 'regions', [
+      'FR-01',
+    ]);
+    // Massif 1, not the soft-deleted fixture massif: `toList` filters deleted
+    // items out of the converted array, so a deleted massif would silently
+    // disappear from the response for reasons unrelated to this endpoint.
+    await TGuideline.addToCollection(deletedWithGeoGuidelineId, 'massifs', [1]);
+    await TGuideline.destroyOne({ id: deletedWithGeoGuidelineId });
+
+    // Left active: the round-trip block below deletes and restores it over HTTP.
+    const roundTrip = await TGuideline.create({
+      title: 'Round Trip Guideline For Find Test',
+      description: 'Deleted then restored by find.test.js.',
+      author: 3,
+      language: 'fra',
+      dateInscription: new Date(),
+    }).fetch();
+    roundTripGuidelineId = roundTrip.id;
+    await TGuideline.addToCollection(roundTripGuidelineId, 'countries', ['FR']);
+    await TGuideline.addToCollection(roundTripGuidelineId, 'regions', [
+      'FR-01',
+    ]);
+    await TGuideline.addToCollection(roundTripGuidelineId, 'massifs', [1]);
 
     // No reviewer: this is the state every guideline is created in, since
     // `create` never sets one. Kept separate from the row above so the
@@ -154,11 +212,75 @@ describe('Guideline find', () => {
       should(res.body).have.property('reviewer', null);
     });
 
-    // Req 2.8: soft-deleted guideline returns 404
-    it('should return 404 for a soft-deleted guideline', (done) => {
+    // Req 2.8, #1804: a soft-deleted guideline stays hidden from the public
+    it('should return 404 for a soft-deleted guideline when anonymous', (done) => {
       supertest(sails.hooks.http.app)
         .get(`/api/v1/guidelines/${deletedGuidelineId}`)
         .expect(404, done);
+    });
+
+    // #1804: authentication alone does not grant the deleted view
+    it('should return 404 for a soft-deleted guideline for an unprivileged user', (done) => {
+      supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${deletedGuidelineId}`)
+        .set('Authorization', userToken)
+        .expect(404, done);
+    });
+
+    // #1804: roles are not hierarchical — Leader is not a lesser Moderator
+    it('should return 404 for a soft-deleted guideline for a Leader', (done) => {
+      supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${deletedGuidelineId}`)
+        .set('Authorization', leaderToken)
+        .expect(404, done);
+    });
+
+    // #1804: a Moderator gets the full hydrated detail, not the reduced deleted
+    // shape the core-content find controllers fall back to. Asserting every
+    // relation also pins that a trigger-driven soft delete leaves the junction
+    // rows and the batched massif-name lookup intact.
+    it('should return 200 with the full hydrated representation for a Moderator on a soft-deleted guideline', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${deletedWithGeoGuidelineId}`)
+        .set('Authorization', moderatorToken)
+        .expect(200);
+
+      const g = res.body;
+      should(g).have.property('id', deletedWithGeoGuidelineId);
+      should(g).have.property('isDeleted', true);
+      should(g).have.property('title').which.is.a.String();
+      should(g.countries).have.length(1);
+      should(g.countries[0]).have.property('id', 'FR');
+      should(g.countries[0]).have.property('name', 'France');
+      should(g.regions).have.length(1);
+      should(g.regions[0]).have.property('id', 'FR-01');
+      should(g.regions[0]).have.property('name', 'Ain');
+      should(g.regions[0]).have.property('countryId', 'FR');
+      should(g.massifs).have.length(1);
+      should(g.massifs[0]).have.property('id', 1);
+      should(g.massifs[0]).have.property('name').which.is.a.String();
+      should(g.massifs[0].name).not.be.empty();
+      should(g.language).have.property('id', 'fra');
+      should(g.language).have.property('refName', 'French');
+      should(g.author).have.property('id', 3);
+      should(g.reviewer).have.property('id', 2);
+    });
+
+    // #1804: an Administrator is granted the same view, because delete and
+    // restore accept either role
+    it('should return the same full representation for an Administrator on a soft-deleted guideline', async () => {
+      const res = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${deletedWithGeoGuidelineId}`)
+        .set('Authorization', adminToken)
+        .expect(200);
+
+      const g = res.body;
+      should(g).have.property('id', deletedWithGeoGuidelineId);
+      should(g).have.property('isDeleted', true);
+      should(g.countries).have.length(1);
+      should(g.regions).have.length(1);
+      should(g.massifs).have.length(1);
+      should(g.language).have.property('refName', 'French');
     });
 
     // Req 2.8: non-existent ID returns 404
@@ -166,6 +288,87 @@ describe('Guideline find', () => {
       supertest(sails.hooks.http.app)
         .get('/api/v1/guidelines/999999')
         .expect(404, done);
+    });
+
+    // #1804: the privileged branch reveals deleted guidelines, never missing ones
+    it('should return 404 for a non-existent guideline ID for a Moderator', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/guidelines/999999')
+        .set('Authorization', moderatorToken)
+        .expect(404, done);
+    });
+
+    it('should return 404 for a non-existent guideline ID for an Administrator', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/guidelines/999999')
+        .set('Authorization', adminToken)
+        .expect(404, done);
+    });
+
+    // #1804: hiding a deleted guideline must not leak that it exists, so the two
+    // 404 bodies have to be identical apart from the id.
+    it('should return the same 404 message for a hidden deleted guideline as for a missing one', async () => {
+      const [deletedRes, missingRes] = await Promise.all([
+        supertest(sails.hooks.http.app)
+          .get(`/api/v1/guidelines/${deletedGuidelineId}`)
+          .expect(404),
+        supertest(sails.hooks.http.app)
+          .get('/api/v1/guidelines/999999')
+          .expect(404),
+      ]);
+
+      should(deletedRes.body.message).equal(
+        `Guideline of id ${deletedGuidelineId} not found.`
+      );
+      should(missingRes.body.message).equal(
+        'Guideline of id 999999 not found.'
+      );
+    });
+
+    // The new privileged branch runs inside the controller, so the validateId
+    // policy must still reject a malformed id before it.
+    it('should still reject a malformed id for a Moderator', (done) => {
+      supertest(sails.hooks.http.app)
+        .get('/api/v1/guidelines/0')
+        .set('Authorization', moderatorToken)
+        .expect(404, done);
+    });
+  });
+
+  // #1804: the exact sequence the web client performs. Every step goes over HTTP
+  // so the `change_guideline` trigger and RecentChangeService run for real, and
+  // the detail GET in step 2 is the one that used to answer 404.
+  describe('delete then privileged detail then restore round trip', () => {
+    it('should let a Moderator read the guideline throughout, without an intermediate 404', async () => {
+      const deleteRes = await supertest(sails.hooks.http.app)
+        .delete(`/api/v1/guidelines/${roundTripGuidelineId}`)
+        .set('Authorization', moderatorToken)
+        .expect(200);
+      should(deleteRes.body).have.property('isDeleted', true);
+
+      const detailRes = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${roundTripGuidelineId}`)
+        .set('Authorization', moderatorToken)
+        .expect(200);
+      should(detailRes.body).have.property('isDeleted', true);
+      should(detailRes.body.countries).have.length(1);
+      should(detailRes.body.regions).have.length(1);
+      should(detailRes.body.massifs).have.length(1);
+
+      await supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${roundTripGuidelineId}`)
+        .expect(404);
+
+      const restoreRes = await supertest(sails.hooks.http.app)
+        .post(`/api/v1/guidelines/${roundTripGuidelineId}/restore`)
+        .set('Authorization', moderatorToken)
+        .expect(200);
+      should(restoreRes.body).have.property('isDeleted', false);
+
+      const publicRes = await supertest(sails.hooks.http.app)
+        .get(`/api/v1/guidelines/${roundTripGuidelineId}`)
+        .expect(200);
+      should(publicRes.body).have.property('isDeleted', false);
     });
   });
 


### PR DESCRIPTION
## 🤔 What

Makes `GET /api/v1/guidelines/{id}` reveal soft-deleted guidelines to privileged callers instead of 404ing everyone.

- Active guideline: `200`, with or without a token (unchanged)
- Soft-deleted, caller is Moderator **or** Administrator: `200` with the hydrated `GuidelineDetail` and `isDeleted: true`
- Soft-deleted, anonymous or unprivileged: `404` (unchanged)
- Missing: `404` for everyone

Closes #1804.

## 🤷‍♂️ Why

The endpoint returned `404` for every soft-deleted guideline — including to the roles that had just deleted it. That broke the standard deleted-entity flow: the soft delete succeeds with `200`, the front end invalidates the detail query, the refetch `404`s, and after a reload there's no way to render the deleted state or expose the restore action.

The front end currently works around this with an `isDeleted=true` UI query parameter plus stale cached data. The parameter never reaches the API, so a reload still `404`s.

Every other soft-deletable entity already keeps its detail endpoint readable by privileged users after deletion. This aligns guidelines with that.

## 🔍 How

`guideline/find.js` reads the optional `req.token` — `parseAuthToken` already populates it on every route when a valid bearer is sent — and falls through to the normal response when the caller holds either role.

Two deliberate departures from the core-content `find` controllers:

- **Checks Moderator and Administrator independently**, not `MODERATOR` alone. Roles aren't hierarchical here, and guideline delete/restore both accept either role, so a Moderator-only gate would let an Administrator soft-delete a guideline and then be unable to read it back — the same bug this fixes, one role over.
- **Returns the full hydrated representation**, not the reduced `toDeletedEntity` shape, following `device/find.js` and `sensor-configuration/find.js`. The front end needs the whole record to render the deleted state and restore action after a reload.

Unprivileged `404`s reuse the missing-id message, so the deleted row's existence isn't leaked.

Scope was kept tight — no policy, service or converter changes were needed. Adding `tokenAuth` would break the public read; `getGuidelineDetail` never filtered `isDeleted`; `toSimpleGuideline` already emits it. No `includeDeleted` parameter.

**Not changed, deliberately:** `PATCH` and `rollback` still `404` on a deleted row for every role. `change_guideline()` only emits an `update` row in `t_last_change` when `is_deleted = false`, so an in-place edit of a deleted guideline would be silently unaudited — and `rollback` has no role check at all, so relaxing it would let a plain user mutate content they can't read. Recorded in `PERMISSION_SYSTEM.md` rather than changed.

## 🧪 Testing

`npm test` — Guidelines folder is **66 passing, 0 failing** (10 new cases).

Full suite shows 4 failures in `Changes/get-recent-comment-relevance-swap.test.js`. **These pre-date this branch**: with the changes stashed, shard 3 is 354 pass / 4 fail; with them, 363 pass / 4 fail — same file, same four tests. That file passes in isolation on clean `develop`, so it's a shard-ordering flake unrelated to this work.

New coverage: anonymous / plain User / Leader all `404`; Moderator and Administrator each `200` with full relations; missing id `404`s for privileged callers too; malformed id still `404`s for a Moderator (pinning that `validateId` runs ahead of the new branch); and the hidden-deleted and missing `404` bodies carry the same message shape, so a refactor can't start leaking existence.

Two notes on test construction:

- The deleted fixture is soft-deleted via `TGuideline.destroyOne` rather than created with `isDeleted: true`, so `histo_delete` runs for real. That makes the test prove the junction rows survive a soft delete — the implicit contract `delete.js` relies on when it echoes pre-delete associations back, previously untestable through the API.
- A round-trip block runs delete → privileged GET → anonymous GET → restore → public GET over HTTP, so the DB trigger and `RecentChangeService` run for real. Step two is the request that used to `404`.

## 📸 Previews

n/a — API only.

## Follow-ups

- **Front end:** can now drop the `isDeleted=true` URL workaround and stay on the canonical detail URL. One caveat: `delete.js` and `restore.js` respond with `toSimpleGuideline` (bare ID strings for countries/regions) while the detail GET returns `toGuideline` (hydrated objects) — so the client must *invalidate* the detail query, not merge the mutation response into cache, or it will clobber the hydrated relations.
- **Docs debt found while auditing, not fixed here:** inconsistency item #3 in `PERMISSION_SYSTEM.md` says `cave/find.js` "forces `isDeleted = false` on list queries" in a way that hides the row. It doesn't — `getPopulatedCave(caveId, subEntitiesWhere)` applies that filter to *sub-entities*, so an anonymous caller gets `200` with a reduced stub, not a `404`. Verified by probe. The wording pre-dates this branch; I dropped the claim from my own additions rather than widen scope. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
